### PR TITLE
Fix golangci-lint local install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It adds other features on top of the functionality offered by the gRPC interface
 - go tools - Installed with the following commands:
 ```
 go install github.com/99designs/gqlgen@latest
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2
 ```
 - gRPC go plugins - Installed with the following commands:
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As the `golangci-lint` [documentation](https://golangci-lint.run/usage/install/) suggests I would use `curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2` instead of `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`.

Their documentation explicitly says: "Note: such go install/go get installation aren't guaranteed to work. We recommend using binary installation."

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
