### PR TITLE
Add basic Unit Test for PutArtifactType logic

### DIFF
--- a/internal/server/grpc_server_test.go
+++ b/internal/server/grpc_server_test.go
@@ -62,10 +62,9 @@ func TestPutArtifactType(t *testing.T) {
 	}
 	t.Logf("Should PutArtifactType: %v", response)
 
-	if *response.TypeId > 0 {
-		t.Logf("Should PutArtifactTypeResponse.TypeId an ID > 0: %v", response)
-	} else {
-		t.Errorf("Should PutArtifactTypeResponse.TypeId an ID > 0: %v", response)
+	t.Logf("Should PutArtifactTypeResponse.TypeId an ID > 0: %v", response)
+	if *response.TypeId <= 0 {
+		t.Fail()
 	}
 }
 

--- a/internal/server/grpc_server_test.go
+++ b/internal/server/grpc_server_test.go
@@ -93,6 +93,6 @@ func TestPutArtifactTypeNoNameFailure(t *testing.T) {
 	if err != nil {
 		t.Logf("Should error on PutArtifactType with Request missing Name: %v", err)
 	} else {
-		t.Errorf("Should error on PutArtifactType with Request missing Name: %v, %v", response, err)
+		t.Errorf("Should error on PutArtifactType with Request missing Name: %v", response)
 	}
 }

--- a/internal/server/grpc_server_test.go
+++ b/internal/server/grpc_server_test.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/opendatahub-io/model-registry/internal/ml_metadata/proto"
+	"github.com/opendatahub-io/model-registry/internal/model/db"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func migrateDatabase(dbConn *gorm.DB) error {
+	// using only needed RDBMS type for the scope under test
+	err := dbConn.AutoMigrate(
+		db.Type{},
+	)
+	if err != nil {
+		return fmt.Errorf("db migration failed: %w", err)
+	}
+	return nil
+}
+
+func setup(tmpFile *os.File) (*gorm.DB, error) {
+	db, err := gorm.Open(sqlite.Open(tmpFile.Name()), &gorm.Config{})
+	if err != nil {
+		return nil, err
+	}
+	err = migrateDatabase(db)
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+// Bare minimal test of PutArtifactType with a given Name
+func TestPutArtifactType(t *testing.T) {
+	f, err := os.CreateTemp("", "model-registry-db")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	db, err := setup(f)
+	if err != nil {
+		t.Errorf("Should expect DB connection: %v", err)
+	}
+	grpcServer := NewGrpcServer(db)
+	artifactTypeName := "test"
+	artifactType := proto.ArtifactType{
+		Name: &artifactTypeName,
+	}
+	req := proto.PutArtifactTypeRequest{
+		ArtifactType: &artifactType,
+	}
+
+	response, err := grpcServer.PutArtifactType(context.Background(), &req)
+	if err != nil {
+		t.Errorf("Should PutArtifactType: %v", err)
+	}
+	t.Logf("Should PutArtifactType: %v", response)
+
+	if *response.TypeId > 0 {
+		t.Logf("Should PutArtifactTypeResponse.TypeId an ID > 0: %v", response)
+	} else {
+		t.Errorf("Should PutArtifactTypeResponse.TypeId an ID > 0: %v", response)
+	}
+}
+
+// Attemping gRPC of PutArtifactType without a Name should error
+func TestPutArtifactTypeNoNameFailure(t *testing.T) {
+	f, err := os.CreateTemp("", "model-registry-db")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	db, err := setup(f)
+	if err != nil {
+		t.Errorf("Should expect DB connection: %v", err)
+	}
+	grpcServer := NewGrpcServer(db)
+	versionName := "test"
+	artifactType := proto.ArtifactType{
+		Name:    nil,
+		Version: &versionName,
+	}
+	req := proto.PutArtifactTypeRequest{
+		ArtifactType: &artifactType,
+	}
+
+	response, err := grpcServer.PutArtifactType(context.Background(), &req)
+	if err != nil {
+		t.Logf("Should error on PutArtifactType with Request missing Name: %v", err)
+	} else {
+		t.Errorf("Should error on PutArtifactType with Request missing Name: %v, %v", response, err)
+	}
+}


### PR DESCRIPTION
introduce basic go test Unit Test
for testing logic of gRPC PutArtifactType

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
```
$ go test -timeout 30s -run PutArtifactType github.com/opendatahub-io/model-registry/internal/server -v
=== RUN   TestPutArtifactType
    grpc_server_test.go:63: Should PutArtifactType: type_id:1
    grpc_server_test.go:66: Should PutArtifactTypeResponse.TypeId an ID > 0: type_id:1
--- PASS: TestPutArtifactType (0.01s)
=== RUN   TestPutArtifactTypeNoNameFailure
    grpc_server_test.go:95: Should error on PutArtifactType with Request missing Name: rpc error: code = Internal desc = server panic: runtime error: invalid memory address or nil pointer dereference
--- PASS: TestPutArtifactTypeNoNameFailure (0.00s)
PASS
ok  	github.com/opendatahub-io/model-registry/internal/server	0.608s
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work (see above)
