### PR TITLE
Implement gRPC GetArtifactType

### DIFF
--- a/test/python/test_mlmetadata.py
+++ b/test/python/test_mlmetadata.py
@@ -45,6 +45,12 @@ def main():
     response = store.PutArtifactType(request)
     model_type_id = response.type_id
 
+    request = metadata_store_service_pb2.GetArtifactTypeRequest()
+    request.type_name = "SavedModel"
+    response = store.GetArtifactType(request)
+    assert response.artifact_type.id == 2
+    assert response.artifact_type.name == "SavedModel"
+
     # Query all registered Artifact types.
     # artifact_types = store.GetArtifactTypes()
 


### PR DESCRIPTION
resolves #25 

## Description
Implement gRPC `GetArtifactType`

## How Has This Been Tested?
in one terminal:

```
make build
make run/server
```

in another terminal:

```
python test/python/test_mlmetadata.py 
```

then running the following python script:

```python
from grpc import insecure_channel
from ml_metadata.proto import metadata_store_service_pb2
from ml_metadata.proto import metadata_store_service_pb2_grpc

def main():
    channel = insecure_channel('localhost:8080')
    store = metadata_store_service_pb2_grpc.MetadataStoreServiceStub(channel)

    request = metadata_store_service_pb2.GetArtifactTypeRequest()
    request.type_name = "SavedModel"

    response = store.GetArtifactType(request)
    print(response)

if __name__ == '__main__':
    main()
```

Outputs as expected:

```
$ python test/python/test_getartifacttype.py 
artifact_type {
  id: 2
  name: "SavedModel"
}
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
