### PR TITLE
Add support for reading config file using viper, fixes #12

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,12 @@
+package cmd
+
+type Config struct {
+	DbFile      string   `mapstructure:"db-file" yaml:"db-file"`
+	Hostname    string   `mapstructure:"hostname" yaml:"hostname"`
+	Port        int      `mapstructure:"port" yaml:"port"`
+	LibraryDirs []string `mapstructure:"metadata-library-dir" yaml:"metadata-library-dir"`
+}
+
+var cfg = Config{DbFile: "metadata.sqlite.db", Hostname: "localhost", Port: 8080, LibraryDirs: []string(nil)}
+
+const EnvPrefix = "MR"

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -23,7 +23,7 @@ This command can create a new ml-metadata Sqlite DB, or migrate an existing DB
 to the latest schema required by this server.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// connect to DB
-		dbConn, err := NewDatabaseConnection(dbFile)
+		dbConn, err := NewDatabaseConnection(cfg.DbFile)
 		defer func() {
 			// close DB connection on exit
 			db, err2 := dbConn.DB()
@@ -76,9 +76,9 @@ func migrateDatabase(dbConn *gorm.DB) error {
 }
 
 func loadLibraries(dbConn *gorm.DB) error {
-	libs, err := library.LoadLibraries(libraryDirs)
+	libs, err := library.LoadLibraries(cfg.LibraryDirs)
 	if err != nil {
-		return fmt.Errorf("failed to read library directories %s: %w", libraryDirs, err)
+		return fmt.Errorf("failed to read library directories %s: %w", cfg.LibraryDirs, err)
 	}
 	for path, lib := range libs {
 		grpcServer := grpc.NewGrpcServer(dbConn)
@@ -128,8 +128,6 @@ func ToProtoProperties(props map[string]library.PropertyType) map[string]proto.P
 	return result
 }
 
-var libraryDirs []string
-
 func init() {
 	rootCmd.AddCommand(migrateCmd)
 
@@ -141,6 +139,6 @@ func init() {
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	migrateCmd.Flags().StringVarP(&dbFile, "db-file", "d", "metadata.sqlite.db", "Sqlite DB file")
-	migrateCmd.Flags().StringSliceVarP(&libraryDirs, "metadata-library-dir", "m", libraryDirs, "Built-in metadata types library directories containing yaml files")
+	migrateCmd.Flags().StringVarP(&cfg.DbFile, "db-file", "d", cfg.DbFile, "Sqlite DB file")
+	migrateCmd.Flags().StringSliceVarP(&cfg.LibraryDirs, "metadata-library-dir", "m", cfg.LibraryDirs, "Built-in metadata types library directories containing yaml files")
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -47,10 +47,6 @@ func InterceptorLogger(l *log.Logger) logging.Logger {
 }
 
 var (
-	dbFile string
-	host       = "localhost"
-	port   int = 8080
-
 	// serveCmd represents the serve command
 	serveCmd = &cobra.Command{
 		Use:   "serve",
@@ -64,7 +60,7 @@ location of the database file and the hostname and port where it listens.'`,
 )
 
 func runServer(cmd *cobra.Command, args []string) error {
-	glog.Info("server started...")
+	glog.Infof("server started at %s:%v", cfg.Hostname, cfg.Port)
 
 	// Create a channel to receive signals
 	signalChannel := make(chan os.Signal, 1)
@@ -73,13 +69,13 @@ func runServer(cmd *cobra.Command, args []string) error {
 	signal.Notify(signalChannel, syscall.SIGINT, syscall.SIGTERM)
 
 	// connect to the DB using Gorm
-	db, err := NewDatabaseConnection(dbFile)
+	db, err := NewDatabaseConnection(cfg.DbFile)
 	if err != nil {
 		log.Fatalf("db connection failed: %v", err)
 	}
 
 	// listen on host:port
-	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", cfg.Hostname, cfg.Port))
 	if err != nil {
 		log.Fatalf("server listen failed: %v", err)
 	}
@@ -189,7 +185,7 @@ func init() {
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	serveCmd.Flags().StringVarP(&dbFile, "db-file", "d", "metadata.sqlite.db", "Sqlite DB file")
-	serveCmd.Flags().StringVarP(&host, "hostname", "n", host, "Server listen hostname")
-	serveCmd.Flags().IntVarP(&port, "port", "p", port, "Server listen port")
+	serveCmd.Flags().StringVarP(&cfg.DbFile, "db-file", "d", cfg.DbFile, "Sqlite DB file")
+	serveCmd.Flags().StringVarP(&cfg.Hostname, "hostname", "n", cfg.Hostname, "Server listen hostname")
+	serveCmd.Flags().IntVarP(&cfg.Port, "port", "p", cfg.Port, "Server listen port")
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/searKing/golang/tools/go-enum v1.2.97
 	github.com/soheilhy/cmux v0.1.5
 	github.com/spf13/cobra v1.7.0
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0
 	github.com/vektah/gqlparser/v2 v2.5.8
 	golang.org/x/sync v0.2.0
@@ -41,7 +42,6 @@ require (
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/urfave/cli/v2 v2.25.5 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add support for reading config file using viper
Also support env variables of the form MR_*. Support overriding config file with environment variables, and command line in order. 

<!--- Describe your changes in detail -->
Fixed viper library calls to make sure config file and environment variables are read first, then overriden if command line options are not set. 

## How Has This Been Tested?
Tested using a yaml config file config.yaml and command line option `-c config.yaml`:
```
db-file: "myfile.sqlite.db"
hostname: "0.0.0.0"
port: 9090
metadata-library-dir: config/metadata-library
```
Also tested by copying the file to `~/.model-registry.yaml`.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work