### PR TITLE
Improve core layer testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ gen: deps gen/grpc gen/openapi gen/graph gen/converter
 .PHONY: lint
 lint: gen
 	golangci-lint run main.go
-	golangci-lint run cmd/... internal/... test/bdd/...
+	golangci-lint run cmd/... internal/...
 
 .PHONY: test
 test: gen

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,10 @@ test: gen
 test-nocache: gen
 	go test ./internal/... -count=1
 
+.PHONY: test-cover
+test-cover: gen
+	go test ./internal/... -cover -count=1
+
 .PHONY: run/migrate
 run/migrate: gen
 	go run main.go migrate --logtostderr=true -m config/metadata-library

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ gen: deps gen/grpc gen/openapi gen/graph gen/converter
 .PHONY: lint
 lint: gen
 	golangci-lint run main.go
-	golangci-lint run cmd/... internal/...
+	golangci-lint run cmd/... internal/... test/bdd/...
 
 .PHONY: test
 test: gen

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -19,7 +19,7 @@ type ModelRegistryApi interface {
 	// approach used by MLMD gRPC api. If Id is provided update the entity otherwise create a new one.
 	UpsertRegisteredModel(registeredModel *openapi.RegisteredModel) (*openapi.RegisteredModel, error)
 
-	GetRegisteredModelById(id *BaseResourceId) (*openapi.RegisteredModel, error)
+	GetRegisteredModelById(id string) (*openapi.RegisteredModel, error)
 	GetRegisteredModelByParams(name *string, externalId *string) (*openapi.RegisteredModel, error)
 	GetRegisteredModels(listOptions ListOptions) (*openapi.RegisteredModelList, error)
 
@@ -27,19 +27,19 @@ type ModelRegistryApi interface {
 
 	// Create a new Model Version
 	// or update a Model Version associated to a specific RegisteredModel identified by parentResourceId parameter
-	UpsertModelVersion(modelVersion *openapi.ModelVersion, parentResourceId *BaseResourceId) (*openapi.ModelVersion, error)
+	UpsertModelVersion(modelVersion *openapi.ModelVersion, parentResourceId *string) (*openapi.ModelVersion, error)
 
-	GetModelVersionById(id *BaseResourceId) (*openapi.ModelVersion, error)
-	GetModelVersionByParams(versionName *string, parentResourceId *BaseResourceId, externalId *string) (*openapi.ModelVersion, error)
-	GetModelVersions(listOptions ListOptions, parentResourceId *BaseResourceId) (*openapi.ModelVersionList, error)
+	GetModelVersionById(id string) (*openapi.ModelVersion, error)
+	GetModelVersionByParams(versionName *string, parentResourceId *string, externalId *string) (*openapi.ModelVersion, error)
+	GetModelVersions(listOptions ListOptions, parentResourceId *string) (*openapi.ModelVersionList, error)
 
 	// MODEL ARTIFACT
 
 	// Create a new Artifact
 	// or update an Artifact associated to a specific ModelVersion identified by parentResourceId parameter
-	UpsertModelArtifact(modelArtifact *openapi.ModelArtifact, parentResourceId *BaseResourceId) (*openapi.ModelArtifact, error)
+	UpsertModelArtifact(modelArtifact *openapi.ModelArtifact, parentResourceId *string) (*openapi.ModelArtifact, error)
 
-	GetModelArtifactById(id *BaseResourceId) (*openapi.ModelArtifact, error)
-	GetModelArtifactByParams(artifactName *string, parentResourceId *BaseResourceId, externalId *string) (*openapi.ModelArtifact, error)
-	GetModelArtifacts(listOptions ListOptions, parentResourceId *BaseResourceId) (*openapi.ModelArtifactList, error)
+	GetModelArtifactById(id string) (*openapi.ModelArtifact, error)
+	GetModelArtifactByParams(artifactName *string, parentResourceId *string, externalId *string) (*openapi.ModelArtifact, error)
+	GetModelArtifacts(listOptions ListOptions, parentResourceId *string) (*openapi.ModelArtifactList, error)
 }

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -99,8 +99,8 @@ func (serv *modelRegistryService) UpsertRegisteredModel(registeredModel *openapi
 		return nil, err
 	}
 
-	modelId := &modelCtxResp.ContextIds[0]
-	model, err := serv.GetRegisteredModelById((*BaseResourceId)(modelId))
+	idAsString := mapper.IdToString(modelCtxResp.ContextIds[0])
+	model, err := serv.GetRegisteredModelById(*idAsString)
 	if err != nil {
 		return nil, err
 	}
@@ -108,18 +108,23 @@ func (serv *modelRegistryService) UpsertRegisteredModel(registeredModel *openapi
 	return model, nil
 }
 
-func (serv *modelRegistryService) GetRegisteredModelById(id *BaseResourceId) (*openapi.RegisteredModel, error) {
-	log.Printf("Getting registered model %d", *id)
+func (serv *modelRegistryService) GetRegisteredModelById(id string) (*openapi.RegisteredModel, error) {
+	log.Printf("Getting registered model %s", id)
+
+	idAsInt, err := mapper.IdToInt64(id)
+	if err != nil {
+		return nil, err
+	}
 
 	getByIdResp, err := serv.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
-		ContextIds: []int64{int64(*id)},
+		ContextIds: []int64{int64(*idAsInt)},
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	if len(getByIdResp.Contexts) != 1 {
-		return nil, fmt.Errorf("multiple registered models found for id %d", *id)
+		return nil, fmt.Errorf("multiple registered models found for id %s", id)
 	}
 
 	regModel, err := serv.mapper.MapToRegisteredModel(getByIdResp.Contexts[0])
@@ -194,16 +199,20 @@ func (serv *modelRegistryService) GetRegisteredModels(listOptions ListOptions) (
 
 // MODEL VERSIONS
 
-func (serv *modelRegistryService) UpsertModelVersion(modelVersion *openapi.ModelVersion, parentResourceId *BaseResourceId) (*openapi.ModelVersion, error) {
+func (serv *modelRegistryService) UpsertModelVersion(modelVersion *openapi.ModelVersion, parentResourceId *string) (*openapi.ModelVersion, error) {
 	if modelVersion.Id == nil {
-		log.Printf("Creating model version for %s", *modelVersion.Name)
+		log.Printf("Creating model version")
 	} else {
-		log.Printf("Updating model version %s for %s", *modelVersion.Id, *modelVersion.Name)
+		log.Printf("Updating model version %s", *modelVersion.Id)
 	}
 
-	registeredModel, err := serv.GetRegisteredModelById(parentResourceId)
+	if parentResourceId == nil {
+		return nil, fmt.Errorf("missing registered model id, cannot create model version without registered model")
+	}
+
+	registeredModel, err := serv.GetRegisteredModelById(*parentResourceId)
 	if err != nil {
-		return nil, fmt.Errorf("not a valid registered model id: %d", *parentResourceId)
+		return nil, fmt.Errorf("not a valid registered model id: %s", *parentResourceId)
 	}
 	registeredModelIdCtxID, err := mapper.IdToInt64(*registeredModel.Id)
 	if err != nil {
@@ -237,7 +246,8 @@ func (serv *modelRegistryService) UpsertModelVersion(modelVersion *openapi.Model
 		}
 	}
 
-	model, err := serv.GetModelVersionById((*BaseResourceId)(modelId))
+	idAsString := mapper.IdToString(*modelId)
+	model, err := serv.GetModelVersionById(*idAsString)
 	if err != nil {
 		return nil, err
 	}
@@ -245,16 +255,21 @@ func (serv *modelRegistryService) UpsertModelVersion(modelVersion *openapi.Model
 	return model, nil
 }
 
-func (serv *modelRegistryService) GetModelVersionById(id *BaseResourceId) (*openapi.ModelVersion, error) {
+func (serv *modelRegistryService) GetModelVersionById(id string) (*openapi.ModelVersion, error) {
+	idAsInt, err := mapper.IdToInt64(id)
+	if err != nil {
+		return nil, err
+	}
+
 	getByIdResp, err := serv.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
-		ContextIds: []int64{int64(*id)},
+		ContextIds: []int64{int64(*idAsInt)},
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	if len(getByIdResp.Contexts) != 1 {
-		return nil, fmt.Errorf("multiple model versions found for id %d", *id)
+		return nil, fmt.Errorf("multiple model versions found for id %s", id)
 	}
 
 	modelVer, err := serv.mapper.MapToModelVersion(getByIdResp.Contexts[0])
@@ -265,10 +280,14 @@ func (serv *modelRegistryService) GetModelVersionById(id *BaseResourceId) (*open
 	return modelVer, nil
 }
 
-func (serv *modelRegistryService) GetModelVersionByParams(versionName *string, parentResourceId *BaseResourceId, externalId *string) (*openapi.ModelVersion, error) {
+func (serv *modelRegistryService) GetModelVersionByParams(versionName *string, parentResourceId *string, externalId *string) (*openapi.ModelVersion, error) {
 	filterQuery := ""
 	if versionName != nil && parentResourceId != nil {
-		filterQuery = fmt.Sprintf("name = \"%s\"", mapper.PrefixWhenOwned((*int64)(parentResourceId), *versionName))
+		idAsInt, err := mapper.IdToInt64(*parentResourceId)
+		if err != nil {
+			return nil, err
+		}
+		filterQuery = fmt.Sprintf("name = \"%s\"", mapper.PrefixWhenOwned(idAsInt, *versionName))
 	} else if externalId != nil {
 		filterQuery = fmt.Sprintf("external_id = \"%s\"", *externalId)
 	}
@@ -294,14 +313,14 @@ func (serv *modelRegistryService) GetModelVersionByParams(versionName *string, p
 	return modelVer, nil
 }
 
-func (serv *modelRegistryService) GetModelVersions(listOptions ListOptions, parentResourceId *BaseResourceId) (*openapi.ModelVersionList, error) {
+func (serv *modelRegistryService) GetModelVersions(listOptions ListOptions, parentResourceId *string) (*openapi.ModelVersionList, error) {
 	listOperationOptions, err := BuildListOperationOptions(listOptions)
 	if err != nil {
 		return nil, err
 	}
 
-	if registeredModelId != nil {
-		queryParentCtxId := fmt.Sprintf("parent_contexts_a.id = %d", *parentResourceId)
+	if parentResourceId != nil {
+		queryParentCtxId := fmt.Sprintf("parent_contexts_a.id = %s", *parentResourceId)
 		listOperationOptions.FilterQuery = &queryParentCtxId
 	}
 
@@ -333,14 +352,18 @@ func (serv *modelRegistryService) GetModelVersions(listOptions ListOptions, pare
 
 // MODEL ARTIFACTS
 
-func (serv *modelRegistryService) UpsertModelArtifact(modelArtifact *openapi.ModelArtifact, parentResourceId *BaseResourceId) (*openapi.ModelArtifact, error) {
+func (serv *modelRegistryService) UpsertModelArtifact(modelArtifact *openapi.ModelArtifact, parentResourceId *string) (*openapi.ModelArtifact, error) {
 	if modelArtifact.Id == nil {
-		log.Printf("Creating model artifact for %s", *modelArtifact.Name)
+		log.Printf("Creating model artifact")
 	} else {
 		log.Printf("Updating model artifact %s", *modelArtifact.Id)
 	}
 
-	artifact := serv.mapper.MapFromModelArtifact(*modelArtifact, (*int64)(parentResourceId))
+	idAsInt, err := mapper.IdToInt64(*parentResourceId)
+	if err != nil {
+		return nil, err
+	}
+	artifact := serv.mapper.MapFromModelArtifact(*modelArtifact, idAsInt)
 
 	artifactsResp, err := serv.mlmdClient.PutArtifacts(context.Background(), &proto.PutArtifactsRequest{
 		Artifacts: []*proto.Artifact{artifact},
@@ -351,11 +374,14 @@ func (serv *modelRegistryService) UpsertModelArtifact(modelArtifact *openapi.Mod
 
 	// add explicit association between artifacts and model version
 	if parentResourceId != nil && modelArtifact.Id == nil {
-		modelVersionIdCtx := int64(*parentResourceId)
+		modelVersionIdCtx, err := mapper.IdToInt64(*parentResourceId)
+		if err != nil {
+			return nil, err
+		}
 		attributions := []*proto.Attribution{}
 		for _, a := range artifactsResp.ArtifactIds {
 			attributions = append(attributions, &proto.Attribution{
-				ContextId:  &modelVersionIdCtx,
+				ContextId:  modelVersionIdCtx,
 				ArtifactId: &a,
 			})
 		}
@@ -368,16 +394,22 @@ func (serv *modelRegistryService) UpsertModelArtifact(modelArtifact *openapi.Mod
 		}
 	}
 
-	mapped, err := serv.GetModelArtifactById((*BaseResourceId)(&artifactsResp.ArtifactIds[0]))
+	idAsString := mapper.IdToString(artifactsResp.ArtifactIds[0])
+	mapped, err := serv.GetModelArtifactById(*idAsString)
 	if err != nil {
 		return nil, err
 	}
 	return mapped, nil
 }
 
-func (serv *modelRegistryService) GetModelArtifactById(id *BaseResourceId) (*openapi.ModelArtifact, error) {
+func (serv *modelRegistryService) GetModelArtifactById(id string) (*openapi.ModelArtifact, error) {
+	idAsInt, err := mapper.IdToInt64(id)
+	if err != nil {
+		return nil, err
+	}
+
 	artifactsResp, err := serv.mlmdClient.GetArtifactsByID(context.Background(), &proto.GetArtifactsByIDRequest{
-		ArtifactIds: []int64{int64(*id)},
+		ArtifactIds: []int64{int64(*idAsInt)},
 	})
 	if err != nil {
 		return nil, err
@@ -391,14 +423,18 @@ func (serv *modelRegistryService) GetModelArtifactById(id *BaseResourceId) (*ope
 	return result, nil
 }
 
-func (serv *modelRegistryService) GetModelArtifactByParams(artifactName *string, parentResourceId *BaseResourceId, externalId *string) (*openapi.ModelArtifact, error) {
+func (serv *modelRegistryService) GetModelArtifactByParams(artifactName *string, parentResourceId *string, externalId *string) (*openapi.ModelArtifact, error) {
 	var artifact0 *proto.Artifact
 
 	filterQuery := ""
 	if externalId != nil {
 		filterQuery = fmt.Sprintf("external_id = \"%s\"", *externalId)
 	} else if artifactName != nil && parentResourceId != nil {
-		filterQuery = fmt.Sprintf("name = \"%s\"", mapper.PrefixWhenOwned((*int64)(parentResourceId), *artifactName))
+		idAsInt, err := mapper.IdToInt64(*parentResourceId)
+		if err != nil {
+			return nil, err
+		}
+		filterQuery = fmt.Sprintf("name = \"%s\"", mapper.PrefixWhenOwned(idAsInt, *artifactName))
 	} else {
 		return nil, fmt.Errorf("invalid parameters call, supply either (artifactName and parentResourceId), or externalId")
 	}
@@ -425,7 +461,7 @@ func (serv *modelRegistryService) GetModelArtifactByParams(artifactName *string,
 	return result, nil
 }
 
-func (serv *modelRegistryService) GetModelArtifacts(listOptions ListOptions, parentResourceId *BaseResourceId) (*openapi.ModelArtifactList, error) {
+func (serv *modelRegistryService) GetModelArtifacts(listOptions ListOptions, parentResourceId *string) (*openapi.ModelArtifactList, error) {
 	listOperationOptions, err := BuildListOperationOptions(listOptions)
 	if err != nil {
 		return nil, err
@@ -434,9 +470,12 @@ func (serv *modelRegistryService) GetModelArtifacts(listOptions ListOptions, par
 	var artifacts []*proto.Artifact
 	var nextPageToken *string
 	if parentResourceId != nil {
-		ctxId := int64(*parentResourceId)
+		ctxId, err := mapper.IdToInt64(*parentResourceId)
+		if err != nil {
+			return nil, err
+		}
 		artifactsResp, err := serv.mlmdClient.GetArtifactsByContext(context.Background(), &proto.GetArtifactsByContextRequest{
-			ContextId: &ctxId,
+			ContextId: ctxId,
 			Options:   listOperationOptions,
 		})
 		if err != nil {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -303,7 +303,7 @@ func (serv *modelRegistryService) GetModelVersionByParams(versionName *string, p
 	}
 
 	if len(getByParamsResp.Contexts) != 1 {
-		return nil, fmt.Errorf("multiple registered models found for versionName=%v, parentResourceId=%v, externalId=%v", zeroIfNil(versionName), zeroIfNil(parentResourceId), zeroIfNil(externalId))
+		return nil, fmt.Errorf("multiple model versions found for versionName=%v, parentResourceId=%v, externalId=%v", zeroIfNil(versionName), zeroIfNil(parentResourceId), zeroIfNil(externalId))
 	}
 
 	modelVer, err := serv.mapper.MapToModelVersion(getByParamsResp.Contexts[0])

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/opendatahub-io/model-registry/internal/core/mapper"
 	"github.com/opendatahub-io/model-registry/internal/ml_metadata/proto"
 	"github.com/opendatahub-io/model-registry/internal/model/openapi"
-	testutils "github.com/opendatahub-io/model-registry/test/utils"
+	"github.com/opendatahub-io/model-registry/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -3,45 +3,174 @@ package core_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/opendatahub-io/model-registry/internal/core"
 	"github.com/opendatahub-io/model-registry/internal/core/mapper"
 	"github.com/opendatahub-io/model-registry/internal/ml_metadata/proto"
 	"github.com/opendatahub-io/model-registry/internal/model/openapi"
+	testutils "github.com/opendatahub-io/model-registry/test/utils"
 	"github.com/stretchr/testify/assert"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
-const (
-	useProvider      = testcontainers.ProviderDefault // or explicit to testcontainers.ProviderPodman if needed
-	mlmdImage        = "gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0"
-	sqliteFile       = "metadata.sqlite.db"
-	testConfigFolder = "test/config/ml-metadata"
+// common utility test variables
+var (
+	// generic
+	ascOrderDirection  string
+	descOrderDirection string
+	// registered models
+	modelName       string
+	modelExternalId string
+	owner           string
+	// model version
+	modelVersionName  string
+	versionExternalId string
+	author            string
+	// model artifact
+	artifactName  string
+	artifactExtId string
+	artifactState string
+	artifactUri   string
 )
 
-func TestCreateRegisteredModel(t *testing.T) {
-	conn, client, teardown := SetupTestContainer(t)
+func setup(t *testing.T) (*assert.Assertions, *grpc.ClientConn, proto.MetadataStoreServiceClient, func(t *testing.T)) {
+	// initialize test variable before each test
+	ascOrderDirection = "ASC"
+	descOrderDirection = "DESC"
+	modelName = "MyAwesomeModel"
+	modelExternalId = "org.myawesomemodel"
+	owner = "owner"
+	modelVersionName = "v1"
+	versionExternalId = "org.myawesomemodel@v1"
+	author = "author1"
+	artifactName = "Pickle model"
+	artifactExtId = "org.myawesomemodel@v1:pickle"
+	artifactState = "LIVE"
+	artifactUri = "path/to/model/v1"
+
+	conn, client, teardown := testutils.SetupMLMDTestContainer(t)
+	return assert.New(t), conn, client, teardown
+}
+
+// initialize model registry service and assert no error is thrown
+func initModelRegistryService(assertion *assert.Assertions, conn *grpc.ClientConn) core.ModelRegistryApi {
+	service, err := core.NewModelRegistryService(conn)
+	assertion.Nilf(err, "error creating core service: %v", err)
+	return service
+}
+
+// utility function that register a new simple model and return its ID
+func registerModel(assertion *assert.Assertions, service core.ModelRegistryApi, overrideModelName *string, overrideExternalId *string) core.BaseResourceId {
+	registeredModel := &openapi.RegisteredModel{
+		Name:       &modelName,
+		ExternalID: &modelExternalId,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"owner": {
+				MetadataStringValue: &openapi.MetadataStringValue{
+					StringValue: &owner,
+				},
+			},
+		},
+	}
+
+	if overrideModelName != nil {
+		registeredModel.Name = overrideModelName
+	}
+
+	if overrideExternalId != nil {
+		registeredModel.ExternalID = overrideExternalId
+	}
+
+	// test
+	createdModel, err := service.UpsertRegisteredModel(registeredModel)
+	assertion.Nilf(err, "error creating registered model: %v", err)
+
+	idAsInt, err := mapper.IdToInt64(*createdModel.Id)
+	assertion.Nilf(err, "error parsing id as int64: %v", err)
+	return (core.BaseResourceId)(*idAsInt)
+}
+
+// utility function that register a new simple model and return its ID
+func registerModelVersion(
+	assertion *assert.Assertions,
+	service core.ModelRegistryApi,
+	overrideModelName *string,
+	overrideExternalId *string,
+	overrideVersionName *string,
+	overrideVersionExtId *string,
+) core.BaseResourceId {
+	registeredModelId := registerModel(assertion, service, overrideModelName, overrideExternalId)
+
+	modelVersion := &openapi.ModelVersion{
+		Name:       &modelVersionName,
+		ExternalID: &versionExternalId,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"author": {
+				MetadataStringValue: &openapi.MetadataStringValue{
+					StringValue: &author,
+				},
+			},
+		},
+	}
+
+	if overrideVersionName != nil {
+		modelVersion.Name = overrideVersionName
+	}
+
+	if overrideVersionExtId != nil {
+		modelVersion.ExternalID = overrideVersionExtId
+	}
+
+	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
+	assertion.Nilf(err, "error creating model version: %v", err)
+
+	idAsInt, err := mapper.IdToInt64(*createdVersion.Id)
+	assertion.Nilf(err, "error parsing id as int64: %v", err)
+	return (core.BaseResourceId)(*idAsInt)
+}
+
+func TestModelRegistryTypes(t *testing.T) {
+	assertion, conn, client, teardown := setup(t)
 	defer teardown(t)
 
-	// [TEST CASE]
+	// create mode registry service
+	_ = initModelRegistryService(assertion, conn)
+
+	// assure the types have been correctly setup at startup
+	ctx := context.Background()
+	regModelResp, _ := client.GetContextType(ctx, &proto.GetContextTypeRequest{
+		TypeName: &core.RegisteredModelTypeName,
+	})
+	assertion.NotNilf(regModelResp.ContextType, "registered model type %s should exists", core.RegisteredModelTypeName)
+	assertion.Equal(core.RegisteredModelTypeName, *regModelResp.ContextType.Name)
+
+	modelVersionResp, _ := client.GetContextType(ctx, &proto.GetContextTypeRequest{
+		TypeName: &core.ModelVersionTypeName,
+	})
+	assertion.NotNilf(modelVersionResp.ContextType, "model version type %s should exists", core.ModelVersionTypeName)
+	assertion.Equal(core.ModelVersionTypeName, *modelVersionResp.ContextType.Name)
+
+	modelArtifactResp, _ := client.GetArtifactType(ctx, &proto.GetArtifactTypeRequest{
+		TypeName: &core.ModelArtifactTypeName,
+	})
+	assertion.NotNilf(modelArtifactResp.ArtifactType, "model version type %s should exists", core.ModelArtifactTypeName)
+	assertion.Equal(core.ModelArtifactTypeName, *modelArtifactResp.ArtifactType.Name)
+}
+
+// REGISTERED MODELS
+
+func TestCreateRegisteredModel(t *testing.T) {
+	assertion, conn, client, teardown := setup(t)
+	defer teardown(t)
 
 	// create mode registry service
-	service, err := core.NewModelRegistryService(conn)
-	assert.Nilf(t, err, "error creating core service: %v", err)
-
-	modelName := "PricingModel"
-	externalId := "myExternalId"
-	owner := "Myself"
+	service := initModelRegistryService(assertion, conn)
 
 	// register a new model
 	registeredModel := &openapi.RegisteredModel{
 		Name:       &modelName,
-		ExternalID: &externalId,
+		ExternalID: &modelExternalId,
 		CustomProperties: &map[string]openapi.MetadataValue{
 			"owner": {
 				MetadataStringValue: &openapi.MetadataStringValue{
@@ -55,144 +184,1016 @@ func TestCreateRegisteredModel(t *testing.T) {
 	createdModel, err := service.UpsertRegisteredModel(registeredModel)
 
 	// checks
-	assert.Nilf(t, err, "error creating registered model: %v", err)
-	assert.NotNilf(t, createdModel.Id, "created registered model should not have nil Id")
+	assertion.Nilf(err, "error creating registered model: %v", err)
+	assertion.NotNilf(createdModel.Id, "created registered model should not have nil Id")
 
 	byTypeAndNameResp, err := client.GetContextByTypeAndName(context.Background(), &proto.GetContextByTypeAndNameRequest{
 		TypeName:    &core.RegisteredModelTypeName,
 		ContextName: &modelName,
 	})
-	assert.Nilf(t, err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
 
 	ctxId := mapper.IdToString(*byTypeAndNameResp.Context.Id)
-	assert.Equal(t, *createdModel.Id, *ctxId, "returned model id should match the mlmd one")
-	assert.Equal(t, modelName, *byTypeAndNameResp.Context.Name, "saved model name should match the provided one")
-	assert.Equal(t, externalId, *byTypeAndNameResp.Context.ExternalId, "saved external id should match the provided one")
-	assert.Equal(t, owner, byTypeAndNameResp.Context.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
+	assertion.Equal(*createdModel.Id, *ctxId, "returned model id should match the mlmd one")
+	assertion.Equal(modelName, *byTypeAndNameResp.Context.Name, "saved model name should match the provided one")
+	assertion.Equal(modelExternalId, *byTypeAndNameResp.Context.ExternalId, "saved external id should match the provided one")
+	assertion.Equal(owner, byTypeAndNameResp.Context.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
 
 	getAllResp, err := client.GetContexts(context.Background(), &proto.GetContextsRequest{})
-	assert.Nilf(t, err, "error retrieving all contexts, not related to the test itself: %v", err)
-	assert.Equal(t, 1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
+	assertion.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
+	assertion.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
 }
 
-func TestGetRegisteredModelById(t *testing.T) {
-	conn, _, teardown := SetupTestContainer(t)
+func TestUpdateRegisteredModel(t *testing.T) {
+	assertion, conn, client, teardown := setup(t)
 	defer teardown(t)
 
-	// [TEST CASE]
-
 	// create mode registry service
-	service, err := core.NewModelRegistryService(conn)
-	assert.Nilf(t, err, "error creating core service: %v", err)
-
-	modelName := "PricingModel"
-	externalId := "mysupermodel"
+	service := initModelRegistryService(assertion, conn)
 
 	// register a new model
 	registeredModel := &openapi.RegisteredModel{
 		Name:       &modelName,
-		ExternalID: &externalId,
+		ExternalID: &modelExternalId,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"owner": {
+				MetadataStringValue: &openapi.MetadataStringValue{
+					StringValue: &owner,
+				},
+			},
+		},
 	}
 
 	// test
 	createdModel, err := service.UpsertRegisteredModel(registeredModel)
 
 	// checks
-	assert.Nilf(t, err, "error creating registered model: %v", err)
+	assertion.Nilf(err, "error creating registered model: %v", err)
+	assertion.NotNilf(createdModel.Id, "created registered model should not have nil Id")
+
+	// checks created model matches original one except for Id
+	assertion.Equal(*registeredModel.Name, *createdModel.Name, "returned model name should match the original one")
+	assertion.Equal(*registeredModel.ExternalID, *createdModel.ExternalID, "returned model external id should match the original one")
+	assertion.Equal(*registeredModel.CustomProperties, *createdModel.CustomProperties, "returned model custom props should match the original one")
+
+	byTypeAndNameResp, err := client.GetContextByTypeAndName(context.Background(), &proto.GetContextByTypeAndNameRequest{
+		TypeName:    &core.RegisteredModelTypeName,
+		ContextName: &modelName,
+	})
+	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+
+	ctxId := mapper.IdToString(*byTypeAndNameResp.Context.Id)
+	assertion.Equal(*createdModel.Id, *ctxId, "returned model id should match the mlmd one")
+	assertion.Equal(modelName, *byTypeAndNameResp.Context.Name, "saved model name should match the provided one")
+	assertion.Equal(modelExternalId, *byTypeAndNameResp.Context.ExternalId, "saved external id should match the provided one")
+	assertion.Equal(owner, byTypeAndNameResp.Context.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
+
+	getAllResp, err := client.GetContexts(context.Background(), &proto.GetContextsRequest{})
+	assertion.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
+	assertion.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
+
+	// update existing model
+	newModelExternalId := "newExternalId"
+	newOwner := "newOwner"
+
+	createdModel.ExternalID = &newModelExternalId
+	(*createdModel.CustomProperties)["owner"] = openapi.MetadataValue{
+		MetadataStringValue: &openapi.MetadataStringValue{
+			StringValue: &newOwner,
+		},
+	}
+
+	// update the model
+	createdModel, err = service.UpsertRegisteredModel(createdModel)
+	assertion.Nilf(err, "error creating registered model: %v", err)
+
+	// still one registered model
+	getAllResp, err = client.GetContexts(context.Background(), &proto.GetContextsRequest{})
+	assertion.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
+	assertion.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
+
+	byTypeAndNameResp, err = client.GetContextByTypeAndName(context.Background(), &proto.GetContextByTypeAndNameRequest{
+		TypeName:    &core.RegisteredModelTypeName,
+		ContextName: &modelName,
+	})
+	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+
+	ctxId = mapper.IdToString(*byTypeAndNameResp.Context.Id)
+	assertion.Equal(*createdModel.Id, *ctxId, "returned model id should match the mlmd one")
+	assertion.Equal(modelName, *byTypeAndNameResp.Context.Name, "saved model name should match the provided one")
+	assertion.Equal(newModelExternalId, *byTypeAndNameResp.Context.ExternalId, "saved external id should match the provided one")
+	assertion.Equal(newOwner, byTypeAndNameResp.Context.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
+}
+
+func TestGetRegisteredModelById(t *testing.T) {
+	assertion, conn, _, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	// register a new model
+	registeredModel := &openapi.RegisteredModel{
+		Name:       &modelName,
+		ExternalID: &modelExternalId,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"owner": {
+				MetadataStringValue: &openapi.MetadataStringValue{
+					StringValue: &owner,
+				},
+			},
+		},
+	}
+
+	// test
+	createdModel, err := service.UpsertRegisteredModel(registeredModel)
+
+	// checks
+	assertion.Nilf(err, "error creating registered model: %v", err)
 
 	modelId, _ := mapper.IdToInt64(*createdModel.Id)
 	getModelById, err := service.GetRegisteredModelById((*core.BaseResourceId)(modelId))
-	assert.Nilf(t, err, "error getting registered model by id %d: %v", *modelId, err)
+	assertion.Nilf(err, "error getting registered model by id %d: %v", *modelId, err)
 
-	assert.Equal(t, modelName, *getModelById.Name, "saved model name should match the provided one")
-	assert.Equal(t, externalId, *getModelById.ExternalID, "saved external id should match the provided one")
+	// checks created model matches original one except for Id
+	assertion.Equal(*registeredModel.Name, *getModelById.Name, "saved model name should match the original one")
+	assertion.Equal(*registeredModel.ExternalID, *getModelById.ExternalID, "saved model external id should match the original one")
+	assertion.Equal(*registeredModel.CustomProperties, *getModelById.CustomProperties, "saved model custom props should match the original one")
 }
 
-// #################
-// ##### Utils #####
-// #################
+func TestGetRegisteredModelByParamsName(t *testing.T) {
+	assertion, conn, _, teardown := setup(t)
+	defer teardown(t)
 
-func clearMetadataSqliteDB(wd string) error {
-	if err := os.Remove(fmt.Sprintf("%s/%s", wd, sqliteFile)); err != nil {
-		return fmt.Errorf("expected to clear sqlite file but didn't find: %v", err)
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	// register a new model
+	registeredModel := &openapi.RegisteredModel{
+		Name:       &modelName,
+		ExternalID: &modelExternalId,
 	}
-	return nil
+
+	createdModel, err := service.UpsertRegisteredModel(registeredModel)
+	assertion.Nilf(err, "error creating registered model: %v", err)
+
+	byName, err := service.GetRegisteredModelByParams(&modelName, nil)
+	assertion.Nilf(err, "error getting registered model by name: %v", err)
+
+	assertion.Equalf(*createdModel.Id, *byName.Id, "the returned model id should match the retrieved by name")
 }
 
-// SetupTestContainer creates a MLMD gRPC test container
-// Returns
-//   - gRPC client connection to the test container
-//   - ml-metadata client used to double check the database
-//   - teardown function
-func SetupTestContainer(t *testing.T) (*grpc.ClientConn, proto.MetadataStoreServiceClient, func(t *testing.T)) {
-	ctx := context.Background()
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Errorf("error getting working directory: %v", err)
-	}
-	wd = fmt.Sprintf("%s/../../%s", wd, testConfigFolder)
-	t.Logf("using working directory: %s", wd)
+func TestGetRegisteredModelByParamsExternalId(t *testing.T) {
+	assertion, conn, _, teardown := setup(t)
+	defer teardown(t)
 
-	req := testcontainers.ContainerRequest{
-		Image:        mlmdImage,
-		ExposedPorts: []string{"8080/tcp"},
-		Env: map[string]string{
-			"METADATA_STORE_SERVER_CONFIG_FILE": "/tmp/shared/conn_config.pb",
-		},
-		Mounts: testcontainers.ContainerMounts{
-			testcontainers.ContainerMount{
-				Source: testcontainers.GenericBindMountSource{
-					HostPath: wd,
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	// register a new model
+	registeredModel := &openapi.RegisteredModel{
+		Name:       &modelName,
+		ExternalID: &modelExternalId,
+	}
+
+	createdModel, err := service.UpsertRegisteredModel(registeredModel)
+	assertion.Nilf(err, "error creating registered model: %v", err)
+
+	byName, err := service.GetRegisteredModelByParams(nil, &modelExternalId)
+	assertion.Nilf(err, "error getting registered model by external id: %v", err)
+
+	assertion.Equalf(*createdModel.Id, *byName.Id, "the returned model id should match the retrieved by name")
+}
+
+func TestGetRegisteredModelsOrderedById(t *testing.T) {
+	assertion, conn, _, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	orderBy := "ID"
+
+	// register a new model
+	registeredModel := &openapi.RegisteredModel{
+		Name:       &modelName,
+		ExternalID: &modelExternalId,
+	}
+
+	_, err := service.UpsertRegisteredModel(registeredModel)
+	assertion.Nilf(err, "error creating registered model: %v", err)
+
+	newModelName := "PricingModel2"
+	newModelExternalId := "myExternalId2"
+	registeredModel.Name = &newModelName
+	registeredModel.ExternalID = &newModelExternalId
+	_, err = service.UpsertRegisteredModel(registeredModel)
+	assertion.Nilf(err, "error creating registered model: %v", err)
+
+	newModelName = "PricingModel3"
+	newModelExternalId = "myExternalId3"
+	registeredModel.Name = &newModelName
+	registeredModel.ExternalID = &newModelExternalId
+	_, err = service.UpsertRegisteredModel(registeredModel)
+	assertion.Nilf(err, "error creating registered model: %v", err)
+
+	orderedById, err := service.GetRegisteredModels(core.ListOptions{
+		OrderBy:   &orderBy,
+		SortOrder: &ascOrderDirection,
+	})
+	assertion.Nilf(err, "error getting registered models: %v", err)
+
+	assertion.Equal(3, int(orderedById.Size))
+	for i := 0; i < int(orderedById.Size)-1; i++ {
+		assertion.Less(*orderedById.Items[i].Id, *orderedById.Items[i+1].Id)
+	}
+
+	orderedById, err = service.GetRegisteredModels(core.ListOptions{
+		OrderBy:   &orderBy,
+		SortOrder: &descOrderDirection,
+	})
+	assertion.Nilf(err, "error getting registered models: %v", err)
+
+	assertion.Equal(3, int(orderedById.Size))
+	for i := 0; i < int(orderedById.Size)-1; i++ {
+		assertion.Greater(*orderedById.Items[i].Id, *orderedById.Items[i+1].Id)
+	}
+}
+
+func TestGetRegisteredModelsOrderedByLastUpdate(t *testing.T) {
+	assertion, conn, _, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	orderBy := "LAST_UPDATE_TIME"
+
+	// register a new model
+	registeredModel := &openapi.RegisteredModel{
+		Name:       &modelName,
+		ExternalID: &modelExternalId,
+	}
+
+	firstModel, err := service.UpsertRegisteredModel(registeredModel)
+	assertion.Nilf(err, "error creating registered model: %v", err)
+
+	newModelName := "PricingModel2"
+	newModelExternalId := "myExternalId2"
+	registeredModel.Name = &newModelName
+	registeredModel.ExternalID = &newModelExternalId
+	secondModel, err := service.UpsertRegisteredModel(registeredModel)
+	assertion.Nilf(err, "error creating registered model: %v", err)
+
+	newModelName = "PricingModel3"
+	newModelExternalId = "myExternalId3"
+	registeredModel.Name = &newModelName
+	registeredModel.ExternalID = &newModelExternalId
+	thirdModel, err := service.UpsertRegisteredModel(registeredModel)
+	assertion.Nilf(err, "error creating registered model: %v", err)
+
+	// update second model
+	secondModel.ExternalID = nil
+	_, err = service.UpsertRegisteredModel(secondModel)
+	assertion.Nilf(err, "error creating registered model: %v", err)
+
+	orderedById, err := service.GetRegisteredModels(core.ListOptions{
+		OrderBy:   &orderBy,
+		SortOrder: &ascOrderDirection,
+	})
+	assertion.Nilf(err, "error getting registered models: %v", err)
+
+	assertion.Equal(3, int(orderedById.Size))
+	assertion.Equal(*firstModel.Id, *orderedById.Items[0].Id)
+	assertion.Equal(*thirdModel.Id, *orderedById.Items[1].Id)
+	assertion.Equal(*secondModel.Id, *orderedById.Items[2].Id)
+
+	orderedById, err = service.GetRegisteredModels(core.ListOptions{
+		OrderBy:   &orderBy,
+		SortOrder: &descOrderDirection,
+	})
+	assertion.Nilf(err, "error getting registered models: %v", err)
+
+	assertion.Equal(3, int(orderedById.Size))
+	assertion.Equal(*secondModel.Id, *orderedById.Items[0].Id)
+	assertion.Equal(*thirdModel.Id, *orderedById.Items[1].Id)
+	assertion.Equal(*firstModel.Id, *orderedById.Items[2].Id)
+}
+
+func TestGetRegisteredModelsWithPageSize(t *testing.T) {
+	assertion, conn, _, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	pageSize := int32(1)
+	pageSize2 := int32(2)
+	modelName := "PricingModel1"
+	modelExternalId := "myExternalId1"
+
+	// register a new model
+	registeredModel := &openapi.RegisteredModel{
+		Name:       &modelName,
+		ExternalID: &modelExternalId,
+	}
+
+	firstModel, err := service.UpsertRegisteredModel(registeredModel)
+	assertion.Nilf(err, "error creating registered model: %v", err)
+
+	newModelName := "PricingModel2"
+	newModelExternalId := "myExternalId2"
+	registeredModel.Name = &newModelName
+	registeredModel.ExternalID = &newModelExternalId
+	secondModel, err := service.UpsertRegisteredModel(registeredModel)
+	assertion.Nilf(err, "error creating registered model: %v", err)
+
+	newModelName = "PricingModel3"
+	newModelExternalId = "myExternalId3"
+	registeredModel.Name = &newModelName
+	registeredModel.ExternalID = &newModelExternalId
+	thirdModel, err := service.UpsertRegisteredModel(registeredModel)
+	assertion.Nilf(err, "error creating registered model: %v", err)
+
+	truncatedList, err := service.GetRegisteredModels(core.ListOptions{
+		PageSize: &pageSize,
+	})
+	assertion.Nilf(err, "error getting registered models: %v", err)
+
+	assertion.Equal(1, int(truncatedList.Size))
+	assertion.NotEqual("", truncatedList.NextPageToken, "next page token should not be empty")
+	assertion.Equal(*firstModel.Id, *truncatedList.Items[0].Id)
+
+	truncatedList, err = service.GetRegisteredModels(core.ListOptions{
+		PageSize:      &pageSize2,
+		NextPageToken: &truncatedList.NextPageToken,
+	})
+	assertion.Nilf(err, "error getting registered models: %v", err)
+
+	assertion.Equal(2, int(truncatedList.Size))
+	assertion.Equal("", truncatedList.NextPageToken, "next page token should be empty as list item returned")
+	assertion.Equal(*secondModel.Id, *truncatedList.Items[0].Id)
+	assertion.Equal(*thirdModel.Id, *truncatedList.Items[1].Id)
+}
+
+// MODEL VERSIONS
+
+func TestCreateModelVersionWithInvalidRegisteredModelId(t *testing.T) {
+	assertion, conn, _, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	notExistingRegisteredModelId := int64(999)
+
+	modelVersion := &openapi.ModelVersion{
+		Name:       &modelVersionName,
+		ExternalID: &versionExternalId,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"author": {
+				MetadataStringValue: &openapi.MetadataStringValue{
+					StringValue: &author,
 				},
-				Target: "/tmp/shared",
 			},
 		},
-		WaitingFor: wait.ForLog("Server listening on"),
 	}
 
-	mlmdgrpc, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ProviderType:     useProvider,
-		ContainerRequest: req,
-		Started:          true,
+	createdVersion, err := service.UpsertModelVersion(modelVersion, (*core.BaseResourceId)(&notExistingRegisteredModelId))
+	assertion.NotNil(err, "model version should fail because registered model id does not exist")
+	assertion.Equal(fmt.Sprintf("not a valid registered model id: %d", notExistingRegisteredModelId), err.Error())
+	assertion.Nil(createdVersion)
+}
+
+func TestCreateModelVersion(t *testing.T) {
+	assertion, conn, client, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	registeredModelId := registerModel(assertion, service, nil, nil)
+
+	modelVersion := &openapi.ModelVersion{
+		Name:       &modelVersionName,
+		ExternalID: &versionExternalId,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"author": {
+				MetadataStringValue: &openapi.MetadataStringValue{
+					StringValue: &author,
+				},
+			},
+		},
+	}
+
+	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
+	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+
+	assertion.NotNilf(createdVersion.Id, "created model version should not have nil Id")
+
+	createdVersionId, _ := mapper.IdToInt64(*createdVersion.Id)
+
+	byId, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+		ContextIds: []int64{
+			*createdVersionId,
+		},
 	})
-	if err != nil {
-		t.Errorf("error setting up mlmd grpc container: %v", err)
+	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	assertion.Equal(1, len(byId.Contexts), "there should be just one context saved in mlmd")
+
+	assertion.Equal(*createdVersionId, *byId.Contexts[0].Id, "returned model id should match the mlmd one")
+	assertion.Equal(fmt.Sprintf("%d:%s", registeredModelId, modelVersionName), *byId.Contexts[0].Name, "saved model name should match the provided one")
+	assertion.Equal(versionExternalId, *byId.Contexts[0].ExternalId, "saved external id should match the provided one")
+	assertion.Equal(author, byId.Contexts[0].CustomProperties["author"].GetStringValue(), "saved author custom property should match the provided one")
+	assertion.Equalf(core.ModelVersionTypeName, *byId.Contexts[0].Type, "saved context should be of type of %s", core.ModelVersionTypeName)
+
+	getAllResp, err := client.GetContexts(context.Background(), &proto.GetContextsRequest{})
+	assertion.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
+	assertion.Equal(2, len(getAllResp.Contexts), "there should be two contexts saved in mlmd")
+}
+
+func TestUpdateModelVersion(t *testing.T) {
+	assertion, conn, client, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	registeredModelId := registerModel(assertion, service, nil, nil)
+
+	modelVersion := &openapi.ModelVersion{
+		Name:       &modelVersionName,
+		ExternalID: &versionExternalId,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"author": {
+				MetadataStringValue: &openapi.MetadataStringValue{
+					StringValue: &author,
+				},
+			},
+		},
 	}
 
-	mappedHost, err := mlmdgrpc.Host(ctx)
-	if err != nil {
-		t.Error(err)
-	}
-	mappedPort, err := mlmdgrpc.MappedPort(ctx, "8080")
-	if err != nil {
-		t.Error(err)
-	}
-	mlmdAddr := fmt.Sprintf("%s:%s", mappedHost, mappedPort.Port())
-	t.Log("MLMD test container setup at: ", mlmdAddr)
+	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
+	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
 
-	// setup grpc connection
-	conn, err := grpc.DialContext(
-		context.Background(),
-		mlmdAddr,
-		grpc.WithReturnConnectionError(),
-		grpc.WithBlock(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	if err != nil {
-		t.Errorf("error dialing connection to mlmd server %s: %v", mlmdAddr, err)
+	assertion.NotNilf(createdVersion.Id, "created model version should not have nil Id")
+	createdVersionId, _ := mapper.IdToInt64(*createdVersion.Id)
+
+	newExternalId := "org.my_awesome_model@v1"
+	newScore := 0.95
+
+	createdVersion.ExternalID = &newExternalId
+	// keep the original name. TODO remove once https://github.com/opendatahub-io/model-registry/pull/79 got merged
+	createdVersion.Name = &modelVersionName
+	(*createdVersion.CustomProperties)["score"] = openapi.MetadataValue{
+		MetadataDoubleValue: &openapi.MetadataDoubleValue{
+			DoubleValue: &newScore,
+		},
 	}
 
-	mlmdClient := proto.NewMetadataStoreServiceClient(conn)
+	updatedVersion, err := service.UpsertModelVersion(createdVersion, &registeredModelId)
+	assertion.Nilf(err, "error updating new model version for %d: %v", registeredModelId, err)
 
-	return conn, mlmdClient, func(t *testing.T) {
-		if err := conn.Close(); err != nil {
-			t.Error(err)
-		}
-		if err := mlmdgrpc.Terminate(ctx); err != nil {
-			t.Error(err)
-		}
-		if err := clearMetadataSqliteDB(wd); err != nil {
-			t.Error(err)
-		}
+	updateVersionId, _ := mapper.IdToInt64(*updatedVersion.Id)
+	assertion.Equal(*createdVersionId, *updateVersionId, "created and updated model version should have same id")
+
+	byId, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+		ContextIds: []int64{
+			*updateVersionId,
+		},
+	})
+	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	assertion.Equal(1, len(byId.Contexts), "there should be just one context saved in mlmd")
+
+	assertion.Equal(*updateVersionId, *byId.Contexts[0].Id, "returned model id should match the mlmd one")
+	assertion.Equal(fmt.Sprintf("%d:%s", registeredModelId, modelVersionName), *byId.Contexts[0].Name, "saved model name should match the provided one")
+	assertion.Equal(newExternalId, *byId.Contexts[0].ExternalId, "saved external id should match the provided one")
+	assertion.Equal(author, byId.Contexts[0].CustomProperties["author"].GetStringValue(), "saved author custom property should match the provided one")
+	assertion.Equal(newScore, byId.Contexts[0].CustomProperties["score"].GetDoubleValue(), "saved score custom property should match the provided one")
+	assertion.Equalf(core.ModelVersionTypeName, *byId.Contexts[0].Type, "saved context should be of type of %s", core.ModelVersionTypeName)
+
+	getAllResp, err := client.GetContexts(context.Background(), &proto.GetContextsRequest{})
+	assertion.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
+	fmt.Printf("%+v", getAllResp.Contexts)
+	assertion.Equal(2, len(getAllResp.Contexts), "there should be two contexts saved in mlmd")
+}
+
+func TestGetModelVersionById(t *testing.T) {
+	assertion, conn, client, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	registeredModelId := registerModel(assertion, service, nil, nil)
+
+	modelVersion := &openapi.ModelVersion{
+		Name:       &modelVersionName,
+		ExternalID: &versionExternalId,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"author": {
+				MetadataStringValue: &openapi.MetadataStringValue{
+					StringValue: &author,
+				},
+			},
+		},
 	}
+
+	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
+	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+
+	assertion.NotNilf(createdVersion.Id, "created model version should not have nil Id")
+	createdVersionId, _ := mapper.IdToInt64(*createdVersion.Id)
+
+	getById, err := service.GetModelVersionById((*core.BaseResourceId)(createdVersionId))
+	assertion.Nilf(err, "error getting model version with id %d", *createdVersionId)
+
+	ctxById, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+		ContextIds: []int64{
+			*createdVersionId,
+		},
+	})
+	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+
+	ctx := ctxById.Contexts[0]
+	assertion.Equal(*getById.Id, *mapper.IdToString(*ctx.Id), "returned model version id should match the mlmd context one")
+	// TODO uncomment once https://github.com/opendatahub-io/model-registry/pull/79 got merged, for now *getById.Name == *ctx.Name
+	// assertion.Equal(fmt.Sprintf("%d:%s", registeredModelId, *getById.Name), *ctx.Name, "saved model name should match the provided one")
+	assertion.Equal(*getById.ExternalID, *modelVersion.ExternalID, "saved external id should match the provided one")
+	assertion.Equal(*(*getById.CustomProperties)["author"].MetadataStringValue.StringValue, author, "saved author custom property should match the provided one")
+}
+
+func TestGetModelVersionByParamsName(t *testing.T) {
+	assertion, conn, client, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	registeredModelId := registerModel(assertion, service, nil, nil)
+
+	modelVersion := &openapi.ModelVersion{
+		Name:       &modelVersionName,
+		ExternalID: &versionExternalId,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"author": {
+				MetadataStringValue: &openapi.MetadataStringValue{
+					StringValue: &author,
+				},
+			},
+		},
+	}
+
+	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
+	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+
+	assertion.NotNilf(createdVersion.Id, "created model version should not have nil Id")
+	createdVersionId, _ := mapper.IdToInt64(*createdVersion.Id)
+
+	// TODO use just modelVersionName once https://github.com/opendatahub-io/model-registry/pull/79 got merged
+	ctxName := fmt.Sprintf("%d:%s", registeredModelId, modelVersionName)
+	getByName, err := service.GetModelVersionByParams(&ctxName, nil)
+	assertion.Nilf(err, "error getting model version by name %d", *createdVersionId)
+
+	ctxById, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+		ContextIds: []int64{
+			*createdVersionId,
+		},
+	})
+	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+
+	ctx := ctxById.Contexts[0]
+	assertion.Equal(*mapper.IdToString(*ctx.Id), *getByName.Id, "returned model version id should match the mlmd context one")
+	// TODO uncomment once https://github.com/opendatahub-io/model-registry/pull/79 got merged, for now *getById.Name == *ctx.Name
+	// assertion.Equal(fmt.Sprintf("%d:%s", registeredModelId, *getById.Name), *ctx.Name, "saved model name should match the provided one")
+	assertion.Equal(*ctx.ExternalId, *getByName.ExternalID, "saved external id should match the provided one")
+	assertion.Equal(ctx.CustomProperties["author"].GetStringValue(), *(*getByName.CustomProperties)["author"].MetadataStringValue.StringValue, "saved author custom property should match the provided one")
+}
+
+func TestGetModelVersionByParamsExternalId(t *testing.T) {
+	assertion, conn, client, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	registeredModelId := registerModel(assertion, service, nil, nil)
+
+	modelVersion := &openapi.ModelVersion{
+		Name:       &modelVersionName,
+		ExternalID: &versionExternalId,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"author": {
+				MetadataStringValue: &openapi.MetadataStringValue{
+					StringValue: &author,
+				},
+			},
+		},
+	}
+
+	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
+	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+
+	assertion.NotNilf(createdVersion.Id, "created model version should not have nil Id")
+	createdVersionId, _ := mapper.IdToInt64(*createdVersion.Id)
+
+	getByExternalId, err := service.GetModelVersionByParams(nil, modelVersion.ExternalID)
+	assertion.Nilf(err, "error getting model version by external id %d", *modelVersion.ExternalID)
+
+	ctxById, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+		ContextIds: []int64{
+			*createdVersionId,
+		},
+	})
+	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+
+	ctx := ctxById.Contexts[0]
+	assertion.Equal(*mapper.IdToString(*ctx.Id), *getByExternalId.Id, "returned model version id should match the mlmd context one")
+	// TODO uncomment once https://github.com/opendatahub-io/model-registry/pull/79 got merged, for now *getById.Name == *ctx.Name
+	// assertion.Equal(fmt.Sprintf("%d:%s", registeredModelId, *getById.Name), *ctx.Name, "saved model name should match the provided one")
+	assertion.Equal(*ctx.ExternalId, *getByExternalId.ExternalID, "saved external id should match the provided one")
+	assertion.Equal(ctx.CustomProperties["author"].GetStringValue(), *(*getByExternalId.CustomProperties)["author"].MetadataStringValue.StringValue, "saved author custom property should match the provided one")
+}
+
+func TestGetModelVersions(t *testing.T) {
+	assertion, conn, _, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	registeredModelId := registerModel(assertion, service, nil, nil)
+
+	modelVersion1 := &openapi.ModelVersion{
+		Name:       &modelVersionName,
+		ExternalID: &versionExternalId,
+	}
+
+	secondModelVersionName := "v2"
+	secondModelVersionExtId := "org.myawesomemodel@v2"
+	modelVersion2 := &openapi.ModelVersion{
+		Name:       &secondModelVersionName,
+		ExternalID: &secondModelVersionExtId,
+	}
+
+	thirdModelVersionName := "v3"
+	thirdModelVersionExtId := "org.myawesomemodel@v3"
+	modelVersion3 := &openapi.ModelVersion{
+		Name:       &thirdModelVersionName,
+		ExternalID: &thirdModelVersionExtId,
+	}
+
+	createdVersion1, err := service.UpsertModelVersion(modelVersion1, &registeredModelId)
+	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+
+	createdVersion2, err := service.UpsertModelVersion(modelVersion2, &registeredModelId)
+	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+
+	createdVersion3, err := service.UpsertModelVersion(modelVersion3, &registeredModelId)
+	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+
+	anotherRegModelName := "AnotherModel"
+	anotherRegModelExtId := "org.another"
+	anotherRegisteredModelId := registerModel(assertion, service, &anotherRegModelName, &anotherRegModelExtId)
+
+	anotherModelVersionName := "v1.0"
+	anotherModelVersionExtId := "org.another@v1.0"
+	modelVersionAnother := &openapi.ModelVersion{
+		Name:       &anotherModelVersionName,
+		ExternalID: &anotherModelVersionExtId,
+	}
+
+	_, err = service.UpsertModelVersion(modelVersionAnother, &anotherRegisteredModelId)
+	assertion.Nilf(err, "error creating new model version for %d", anotherRegisteredModelId)
+
+	createdVersionId1, _ := mapper.IdToInt64(*createdVersion1.Id)
+	createdVersionId2, _ := mapper.IdToInt64(*createdVersion2.Id)
+	createdVersionId3, _ := mapper.IdToInt64(*createdVersion3.Id)
+
+	getAll, err := service.GetModelVersions(core.ListOptions{}, nil)
+	assertion.Nilf(err, "error getting all model versions")
+	assertion.Equal(int32(4), getAll.Size, "expected four model versions across all registered models")
+
+	getAllByRegModel, err := service.GetModelVersions(core.ListOptions{}, &registeredModelId)
+	assertion.Nilf(err, "error getting all model versions")
+	assertion.Equalf(int32(3), getAllByRegModel.Size, "expected three model versions for registered model %d", registeredModelId)
+
+	assertion.Equal(*mapper.IdToString(*createdVersionId1), *getAllByRegModel.Items[0].Id)
+	assertion.Equal(*mapper.IdToString(*createdVersionId2), *getAllByRegModel.Items[1].Id)
+	assertion.Equal(*mapper.IdToString(*createdVersionId3), *getAllByRegModel.Items[2].Id)
+
+	// order by last update time, expecting last created as first
+	orderByLastUpdate := "LAST_UPDATE_TIME"
+	getAllByRegModel, err = service.GetModelVersions(core.ListOptions{
+		OrderBy:   &orderByLastUpdate,
+		SortOrder: &descOrderDirection,
+	}, &registeredModelId)
+	assertion.Nilf(err, "error getting all model versions")
+	assertion.Equalf(int32(3), getAllByRegModel.Size, "expected three model versions for registered model %d", registeredModelId)
+
+	assertion.Equal(*mapper.IdToString(*createdVersionId1), *getAllByRegModel.Items[2].Id)
+	assertion.Equal(*mapper.IdToString(*createdVersionId2), *getAllByRegModel.Items[1].Id)
+	assertion.Equal(*mapper.IdToString(*createdVersionId3), *getAllByRegModel.Items[0].Id)
+
+	// update the second version
+	newVersionExternalId := "updated.org:v2"
+	createdVersion2.ExternalID = &newVersionExternalId
+	createdVersion2, err = service.UpsertModelVersion(createdVersion2, &registeredModelId)
+	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+
+	assertion.Equal(newVersionExternalId, *createdVersion2.ExternalID)
+
+	getAllByRegModel, err = service.GetModelVersions(core.ListOptions{
+		OrderBy:   &orderByLastUpdate,
+		SortOrder: &descOrderDirection,
+	}, &registeredModelId)
+	assertion.Nilf(err, "error getting all model versions")
+	assertion.Equalf(int32(3), getAllByRegModel.Size, "expected three model versions for registered model %d", registeredModelId)
+
+	assertion.Equal(*mapper.IdToString(*createdVersionId1), *getAllByRegModel.Items[2].Id)
+	assertion.Equal(*mapper.IdToString(*createdVersionId2), *getAllByRegModel.Items[0].Id)
+	assertion.Equal(*mapper.IdToString(*createdVersionId3), *getAllByRegModel.Items[1].Id)
+}
+
+// MODEL ARTIFACTS
+
+func TestCreateModelArtifact(t *testing.T) {
+	assertion, conn, client, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	modelVersionId := registerModelVersion(assertion, service, nil, nil, nil, nil)
+
+	modelArtifact := &openapi.ModelArtifact{
+		Name:  &artifactName,
+		State: (*openapi.ArtifactState)(&artifactState),
+		Uri:   &artifactUri,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"author": {
+				MetadataStringValue: &openapi.MetadataStringValue{
+					StringValue: &author,
+				},
+			},
+		},
+	}
+
+	createdArtifact, err := service.UpsertModelArtifact(modelArtifact, &modelVersionId)
+	assertion.Nilf(err, "error creating new model artifact for %d", modelVersionId)
+
+	state, _ := openapi.NewArtifactStateFromValue(artifactState)
+	assertion.NotNil(createdArtifact.Id, "created artifact id should not be nil")
+	assertion.Equal(artifactName, *createdArtifact.Name)
+	assertion.Equal(*state, *createdArtifact.State)
+	assertion.Equal(artifactUri, *createdArtifact.Uri)
+	assertion.Equal(author, *(*createdArtifact.CustomProperties)["author"].MetadataStringValue.StringValue)
+
+	createdArtifactId, _ := mapper.IdToInt64(*createdArtifact.Id)
+	getById, err := client.GetArtifactsByID(context.Background(), &proto.GetArtifactsByIDRequest{
+		ArtifactIds: []int64{*createdArtifactId},
+	})
+	assertion.Nilf(err, "error getting model artifact by id %d", createdArtifactId)
+
+	assertion.Equal(*createdArtifactId, *getById.Artifacts[0].Id)
+	assertion.Equal(*createdArtifact.Name, *getById.Artifacts[0].Name)
+	assertion.Equal(string(*createdArtifact.State), getById.Artifacts[0].State.String())
+	assertion.Equal(*createdArtifact.Uri, *getById.Artifacts[0].Uri)
+	assertion.Equal(*(*createdArtifact.CustomProperties)["author"].MetadataStringValue.StringValue, getById.Artifacts[0].CustomProperties["author"].GetStringValue())
+
+	byCtx, _ := client.GetArtifactsByContext(context.Background(), &proto.GetArtifactsByContextRequest{
+		ContextId: (*int64)(&modelVersionId),
+	})
+	assertion.Equal(1, len(byCtx.Artifacts))
+	assertion.Equal(*createdArtifactId, *byCtx.Artifacts[0].Id)
+}
+
+func TestUpdateModelArtifact(t *testing.T) {
+	assertion, conn, client, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	modelVersionId := registerModelVersion(assertion, service, nil, nil, nil, nil)
+
+	modelArtifact := &openapi.ModelArtifact{
+		Name:  &artifactName,
+		State: (*openapi.ArtifactState)(&artifactState),
+		Uri:   &artifactUri,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"author": {
+				MetadataStringValue: &openapi.MetadataStringValue{
+					StringValue: &author,
+				},
+			},
+		},
+	}
+
+	createdArtifact, err := service.UpsertModelArtifact(modelArtifact, &modelVersionId)
+	assertion.Nilf(err, "error creating new model artifact for %d", modelVersionId)
+
+	newState := "MARKED_FOR_DELETION"
+	createdArtifact.State = (*openapi.ArtifactState)(&newState)
+	updatedArtifact, err := service.UpsertModelArtifact(createdArtifact, &modelVersionId)
+	assertion.Nilf(err, "error updating model artifact for %d: %v", modelVersionId, err)
+
+	createdArtifactId, _ := mapper.IdToInt64(*createdArtifact.Id)
+	updatedArtifactId, _ := mapper.IdToInt64(*updatedArtifact.Id)
+	assertion.Equal(createdArtifactId, updatedArtifactId)
+
+	getById, err := client.GetArtifactsByID(context.Background(), &proto.GetArtifactsByIDRequest{
+		ArtifactIds: []int64{*createdArtifactId},
+	})
+	assertion.Nilf(err, "error getting model artifact by id %d", createdArtifactId)
+
+	assertion.Equal(*createdArtifactId, *getById.Artifacts[0].Id)
+	assertion.Equal(*createdArtifact.Name, *getById.Artifacts[0].Name)
+	assertion.Equal(string(newState), getById.Artifacts[0].State.String())
+	assertion.Equal(*createdArtifact.Uri, *getById.Artifacts[0].Uri)
+	assertion.Equal(*(*createdArtifact.CustomProperties)["author"].MetadataStringValue.StringValue, getById.Artifacts[0].CustomProperties["author"].GetStringValue())
+}
+
+func TestGetModelArtifactById(t *testing.T) {
+	assertion, conn, _, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	modelVersionId := registerModelVersion(assertion, service, nil, nil, nil, nil)
+
+	modelArtifact := &openapi.ModelArtifact{
+		Name:  &artifactName,
+		State: (*openapi.ArtifactState)(&artifactState),
+		Uri:   &artifactUri,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"author": {
+				MetadataStringValue: &openapi.MetadataStringValue{
+					StringValue: &author,
+				},
+			},
+		},
+	}
+
+	createdArtifact, err := service.UpsertModelArtifact(modelArtifact, &modelVersionId)
+	assertion.Nilf(err, "error creating new model artifact for %d", modelVersionId)
+
+	createdArtifactId, _ := mapper.IdToInt64(*createdArtifact.Id)
+
+	getById, err := service.GetModelArtifactById((*core.BaseResourceId)(createdArtifactId))
+	assertion.Nilf(err, "error getting model artifact by id %d", createdArtifactId)
+
+	state, _ := openapi.NewArtifactStateFromValue(artifactState)
+	assertion.NotNil(createdArtifact.Id, "created artifact id should not be nil")
+	assertion.Equal(artifactName, *getById.Name)
+	assertion.Equal(*state, *getById.State)
+	assertion.Equal(artifactUri, *getById.Uri)
+	assertion.Equal(author, *(*getById.CustomProperties)["author"].MetadataStringValue.StringValue)
+
+	assertion.Equal(*createdArtifact, *getById, "artifacts returned during creation and on get by id should be equal")
+}
+
+func TestGetModelArtifactByParams(t *testing.T) {
+	assertion, conn, _, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	modelVersionId := registerModelVersion(assertion, service, nil, nil, nil, nil)
+
+	modelArtifact := &openapi.ModelArtifact{
+		Name:       &artifactName,
+		State:      (*openapi.ArtifactState)(&artifactState),
+		Uri:        &artifactUri,
+		ExternalID: &artifactExtId,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"author": {
+				MetadataStringValue: &openapi.MetadataStringValue{
+					StringValue: &author,
+				},
+			},
+		},
+	}
+
+	createdArtifact, err := service.UpsertModelArtifact(modelArtifact, &modelVersionId)
+	assertion.Nilf(err, "error creating new model artifact for %d", modelVersionId)
+
+	createdArtifactId, _ := mapper.IdToInt64(*createdArtifact.Id)
+
+	state, _ := openapi.NewArtifactStateFromValue(artifactState)
+
+	getByName, err := service.GetModelArtifactByParams(&artifactName, nil)
+	assertion.Nilf(err, "error getting model artifact by id %d", createdArtifactId)
+
+	assertion.NotNil(createdArtifact.Id, "created artifact id should not be nil")
+	assertion.Equal(artifactName, *getByName.Name)
+	assertion.Equal(artifactExtId, *getByName.ExternalID)
+	assertion.Equal(*state, *getByName.State)
+	assertion.Equal(artifactUri, *getByName.Uri)
+	assertion.Equal(author, *(*getByName.CustomProperties)["author"].MetadataStringValue.StringValue)
+
+	assertion.Equal(*createdArtifact, *getByName, "artifacts returned during creation and on get by name should be equal")
+
+	getByExtId, err := service.GetModelArtifactByParams(nil, &artifactExtId)
+	assertion.Nilf(err, "error getting model artifact by id %d", createdArtifactId)
+
+	assertion.NotNil(createdArtifact.Id, "created artifact id should not be nil")
+	assertion.Equal(artifactName, *getByExtId.Name)
+	assertion.Equal(artifactExtId, *getByExtId.ExternalID)
+	assertion.Equal(*state, *getByExtId.State)
+	assertion.Equal(artifactUri, *getByExtId.Uri)
+	assertion.Equal(author, *(*getByExtId.CustomProperties)["author"].MetadataStringValue.StringValue)
+
+	assertion.Equal(*createdArtifact, *getByExtId, "artifacts returned during creation and on get by ext id should be equal")
+}
+
+func TestGetModelArtifacts(t *testing.T) {
+	assertion, conn, _, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	modelVersionId := registerModelVersion(assertion, service, nil, nil, nil, nil)
+
+	modelArtifact1 := &openapi.ModelArtifact{
+		Name:       &artifactName,
+		State:      (*openapi.ArtifactState)(&artifactState),
+		Uri:        &artifactUri,
+		ExternalID: &artifactExtId,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"author": {
+				MetadataStringValue: &openapi.MetadataStringValue{
+					StringValue: &author,
+				},
+			},
+		},
+	}
+
+	secondArtifactName := "second-name"
+	secondArtifactExtId := "second-ext-id"
+	secondArtifactUri := "second-uri"
+	modelArtifact2 := &openapi.ModelArtifact{
+		Name:       &secondArtifactName,
+		State:      (*openapi.ArtifactState)(&artifactState),
+		Uri:        &secondArtifactUri,
+		ExternalID: &secondArtifactExtId,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"author": {
+				MetadataStringValue: &openapi.MetadataStringValue{
+					StringValue: &author,
+				},
+			},
+		},
+	}
+
+	thirdArtifactName := "third-name"
+	thirdArtifactExtId := "third-ext-id"
+	thirdArtifactUri := "third-uri"
+	modelArtifact3 := &openapi.ModelArtifact{
+		Name:       &thirdArtifactName,
+		State:      (*openapi.ArtifactState)(&artifactState),
+		Uri:        &thirdArtifactUri,
+		ExternalID: &thirdArtifactExtId,
+		CustomProperties: &map[string]openapi.MetadataValue{
+			"author": {
+				MetadataStringValue: &openapi.MetadataStringValue{
+					StringValue: &author,
+				},
+			},
+		},
+	}
+
+	createdArtifact1, err := service.UpsertModelArtifact(modelArtifact1, &modelVersionId)
+	assertion.Nilf(err, "error creating new model artifact for %d", modelVersionId)
+	createdArtifact2, err := service.UpsertModelArtifact(modelArtifact2, &modelVersionId)
+	assertion.Nilf(err, "error creating new model artifact for %d", modelVersionId)
+	createdArtifact3, err := service.UpsertModelArtifact(modelArtifact3, &modelVersionId)
+	assertion.Nilf(err, "error creating new model artifact for %d", modelVersionId)
+
+	createdArtifactId1, _ := mapper.IdToInt64(*createdArtifact1.Id)
+	createdArtifactId2, _ := mapper.IdToInt64(*createdArtifact2.Id)
+	createdArtifactId3, _ := mapper.IdToInt64(*createdArtifact3.Id)
+
+	getAll, err := service.GetModelArtifacts(core.ListOptions{}, nil)
+	assertion.Nilf(err, "error getting all model artifacts")
+	assertion.Equalf(int32(3), getAll.Size, "expected three model artifacts")
+
+	assertion.Equal(*mapper.IdToString(*createdArtifactId1), *getAll.Items[0].Id)
+	assertion.Equal(*mapper.IdToString(*createdArtifactId2), *getAll.Items[1].Id)
+	assertion.Equal(*mapper.IdToString(*createdArtifactId3), *getAll.Items[2].Id)
+
+	orderByLastUpdate := "LAST_UPDATE_TIME"
+	getAllByModelVersion, err := service.GetModelArtifacts(core.ListOptions{
+		OrderBy:   &orderByLastUpdate,
+		SortOrder: &descOrderDirection,
+	}, &modelVersionId)
+	assertion.Nilf(err, "error getting all model artifacts for %d", modelVersionId)
+	assertion.Equalf(int32(3), getAllByModelVersion.Size, "expected three model artifacts for model version %d", modelVersionId)
+
+	assertion.Equal(*mapper.IdToString(*createdArtifactId1), *getAllByModelVersion.Items[2].Id)
+	assertion.Equal(*mapper.IdToString(*createdArtifactId2), *getAllByModelVersion.Items[1].Id)
+	assertion.Equal(*mapper.IdToString(*createdArtifactId3), *getAllByModelVersion.Items[0].Id)
 }

--- a/internal/testutils/test_container_utils.go
+++ b/internal/testutils/test_container_utils.go
@@ -1,4 +1,4 @@
-package utils_test
+package testutils
 
 import (
 	"context"

--- a/test/bdd/mr_service_features_test.go
+++ b/test/bdd/mr_service_features_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strconv"
 	"testing"
 
 	"github.com/cucumber/godog"
@@ -80,36 +79,17 @@ func iStoreARegisteredModelWithNameAndAChildModelVersionWithNameAndAChildArtifac
 	if err != nil {
 		return err
 	}
-	registeredModelId, err := idToInt64(*registeredModel.Id)
-	if err != nil {
-		return err
-	}
 
 	var modelVersion *openapi.ModelVersion
-	if modelVersion, err = service.UpsertModelVersion(&openapi.ModelVersion{Name: &modelVersionName}, (*core.BaseResourceId)(registeredModelId)); err != nil {
-		return err
-	}
-	modelVersionId, err := idToInt64(*modelVersion.Id)
-	if err != nil {
+	if modelVersion, err = service.UpsertModelVersion(&openapi.ModelVersion{Name: &modelVersionName}, registeredModel.Id); err != nil {
 		return err
 	}
 
-	if _, err = service.UpsertModelArtifact(&openapi.ModelArtifact{Uri: &artifactURI}, (*core.BaseResourceId)(modelVersionId)); err != nil {
+	if _, err = service.UpsertModelArtifact(&openapi.ModelArtifact{Uri: &artifactURI}, modelVersion.Id); err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func idToInt64(idString string) (*int64, error) {
-	idInt, err := strconv.Atoi(idString)
-	if err != nil {
-		return nil, err
-	}
-
-	idInt64 := int64(idInt)
-
-	return &idInt64, nil
 }
 
 func thereShouldBeAMlmdContextOfTypeNamed(ctx context.Context, arg1, arg2 string) error {
@@ -183,7 +163,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 			return ctx, err
 		}
 		wd := ctx.Value(wdCtxKey{}).(string)
-		clearMetadataSqliteDB(wd)
+		_ = clearMetadataSqliteDB(wd)
 		return ctx, nil
 	})
 }

--- a/test/utils/test_container_utils.go
+++ b/test/utils/test_container_utils.go
@@ -1,0 +1,106 @@
+package utils_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/opendatahub-io/model-registry/internal/ml_metadata/proto"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const (
+	useProvider      = testcontainers.ProviderDefault // or explicit to testcontainers.ProviderPodman if needed
+	mlmdImage        = "gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0"
+	sqliteFile       = "metadata.sqlite.db"
+	testConfigFolder = "test/config/ml-metadata"
+)
+
+func clearMetadataSqliteDB(wd string) error {
+	if err := os.Remove(fmt.Sprintf("%s/%s", wd, sqliteFile)); err != nil {
+		return fmt.Errorf("expected to clear sqlite file but didn't find: %v", err)
+	}
+	return nil
+}
+
+// SetupMLMDTestContainer creates a MLMD gRPC test container
+// Returns
+//   - gRPC client connection to the test container
+//   - ml-metadata client used to double check the database
+//   - teardown function
+func SetupMLMDTestContainer(t *testing.T) (*grpc.ClientConn, proto.MetadataStoreServiceClient, func(t *testing.T)) {
+	ctx := context.Background()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Errorf("error getting working directory: %v", err)
+	}
+	wd = fmt.Sprintf("%s/../../%s", wd, testConfigFolder)
+	t.Logf("using working directory: %s", wd)
+
+	req := testcontainers.ContainerRequest{
+		Image:        mlmdImage,
+		ExposedPorts: []string{"8080/tcp"},
+		Env: map[string]string{
+			"METADATA_STORE_SERVER_CONFIG_FILE": "/tmp/shared/conn_config.pb",
+		},
+		Mounts: testcontainers.ContainerMounts{
+			testcontainers.ContainerMount{
+				Source: testcontainers.GenericBindMountSource{
+					HostPath: wd,
+				},
+				Target: "/tmp/shared",
+			},
+		},
+		WaitingFor: wait.ForLog("Server listening on"),
+	}
+
+	mlmdgrpc, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ProviderType:     useProvider,
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		t.Errorf("error setting up mlmd grpc container: %v", err)
+	}
+
+	mappedHost, err := mlmdgrpc.Host(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+	mappedPort, err := mlmdgrpc.MappedPort(ctx, "8080")
+	if err != nil {
+		t.Error(err)
+	}
+	mlmdAddr := fmt.Sprintf("%s:%s", mappedHost, mappedPort.Port())
+	t.Log("MLMD test container setup at: ", mlmdAddr)
+
+	// setup grpc connection
+	conn, err := grpc.DialContext(
+		context.Background(),
+		mlmdAddr,
+		grpc.WithReturnConnectionError(),
+		grpc.WithBlock(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Errorf("error dialing connection to mlmd server %s: %v", mlmdAddr, err)
+	}
+
+	mlmdClient := proto.NewMetadataStoreServiceClient(conn)
+
+	return conn, mlmdClient, func(t *testing.T) {
+		if err := conn.Close(); err != nil {
+			t.Error(err)
+		}
+		if err := mlmdgrpc.Terminate(ctx); err != nil {
+			t.Error(err)
+		}
+		if err := clearMetadataSqliteDB(wd); err != nil {
+			t.Error(err)
+		}
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/opendatahub-io/model-registry/issues/82

## Description
Improved the `core` package unit testing, was able to reach `79.5%` of coverage on thsi package:
```bash
ok github.com/opendatahub-io/model-registry/internal/core coverage: 79.5% of statements
```

During this testing improvement I also fixed some mapping issues that I found and I slightly change the exposed api by treating `IDs` as `string` rather than `BaseResourceId`, in this way the type is coherent with the internal model and what is returned to the user.

*Pre-requisites:*
- [x] Merge https://github.com/opendatahub-io/model-registry/pull/79 first and then rebase this PR by properly fixing remaining `TODOs` in `core_test.go`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running:
```bash
make test
```

With coverager
```bash
make test-cover
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
