### PR TITLE
Export QUAY_ORG for latest tag

### DIFF
--- a/.github/workflows/build-image-main.yml
+++ b/.github/workflows/build-image-main.yml
@@ -5,6 +5,7 @@ on:
     branches: [ 'main' ]
 
 env:
+  QUAY_ORG: opendatahub
   QUAY_IMG_REPO: model-registry
   QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
   QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/scripts/build_deploy.sh
+++ b/scripts/build_deploy.sh
@@ -63,7 +63,7 @@ if [[ "${PUSH_IMAGE,,}" == "true" ]]; then
     IMG_ORG="${QUAY_ORG}" \
     IMG_REPO="${QUAY_IMG_REPO}" \
     IMG_VERSION="${VERSION}" \
-    DOCKER_USER="${QUAY_USERNAME} "\
+    DOCKER_USER="${QUAY_USERNAME}"\
     DOCKER_PWD="${QUAY_PASSWORD}" \
     docker/login \
     image/push


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix issue during container image tag:
```
Run docker tag quay.io//model-registry:main-d53fd86 quay.io//model-registry:latest
Error parsing reference: "quay.io//model-registry:main-d53fd86" is not a valid repository/tag: invalid reference format
```

The fix is about exporting `QUAY_ORG` env variable that was missing in the workflow and this is gonna be correctly used here: `IMG: quay.io/${{ env.QUAY_ORG }}/${{ env.QUAY_IMG_REPO }}`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
