### PR TITLE
Skip pr checks when changing files not affecting the build

### DIFF
--- a/.github/workflows/build-image-main.yml
+++ b/.github/workflows/build-image-main.yml
@@ -2,7 +2,8 @@ name: Main container image build and tag
 
 on:
   push:
-    branches: [ 'main' ]
+    branches:
+      - 'main'
 
 env:
   QUAY_ORG: opendatahub

--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -2,7 +2,16 @@ name: Test container image build
 
 on:
   pull_request_target:
-    branches: [ '*' ]
+    branches:
+      - '*'
+    paths-ignore:
+      - 'LICENSE*'
+      - '**.gitignore'
+      - '**.md'
+      - '**.txt'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/dependabot.yml'
+      - 'docs/**'
 
 env:
   QUAY_IMG_REPO: model-registry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,21 @@ name: Build
 
 on:
   push:
-    branches: [ 'main' ]
+    branches:
+      - 'main'
   pull_request:
-    branches: [ '*' ]
+    branches:
+      - '*'
+    paths-ignore:
+      - 'LICENSE*'
+      - 'DOCKERFILE*'
+      - '**.gitignore'
+      - '**.md'
+      - '**.txt'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/dependabot.yml'
+      - 'docs/**'
+      - 'scripts/**'
 
 jobs:
   build:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/opendatahub-io/model-registry/issues/93

## Description
<!--- Describe your changes in detail -->

Using `paths-ignore`, skip running build checks when updating files that are not affecting the build itself like txt files and so on.

PS: also formatted workflows to use yml list notation on all configs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
