### PR TITLE
workflows: fix branch restriction on pull requests

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -2,8 +2,6 @@ name: Test container image build
 
 on:
   pull_request_target:
-    branches:
-      - '*'
     paths-ignore:
       - 'LICENSE*'
       - '**.gitignore'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - 'main'
   pull_request:
-    branches:
-      - '*'
     paths-ignore:
       - 'LICENSE*'
       - 'DOCKERFILE*'


### PR DESCRIPTION
As we actually want to run those workflows for any branches, we should either specify "**" to include names with slashes (/) or simply omit the restriction.

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] The developer has manually tested the changes and verified that the changes work
