### PR TITLE
Improve core layer optional params management

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -79,10 +79,26 @@ func NewModelRegistryService(cc grpc.ClientConnInterface) (ModelRegistryApi, err
 // REGISTERED MODELS
 
 func (serv *modelRegistryService) UpsertRegisteredModel(registeredModel *openapi.RegisteredModel) (*openapi.RegisteredModel, error) {
+	var err error
+	var existing *openapi.RegisteredModel
+
 	if registeredModel.Id == nil {
-		log.Printf("Creating registered model for %s", *registeredModel.Name)
+		log.Printf("Creating new registered model")
 	} else {
-		log.Printf("Updating registered model %s for %s", *registeredModel.Id, *registeredModel.Name)
+		log.Printf("Updating registered model %s", *registeredModel.Id)
+		existing, err = serv.GetRegisteredModelById(*registeredModel.Id)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// if already existing assure the name is the same
+	if existing != nil {
+		if registeredModel.Name == nil {
+			// user did not provide it
+			// need to set it to avoid mlmd error "context name should not be empty"
+			registeredModel.Name = existing.Name
+		}
 	}
 
 	modelCtx, err := serv.mapper.MapFromRegisteredModel(registeredModel)
@@ -123,11 +139,46 @@ func (serv *modelRegistryService) GetRegisteredModelById(id string) (*openapi.Re
 		return nil, err
 	}
 
-	if len(getByIdResp.Contexts) != 1 {
+	if len(getByIdResp.Contexts) > 1 {
 		return nil, fmt.Errorf("multiple registered models found for id %s", id)
 	}
 
+	if len(getByIdResp.Contexts) == 0 {
+		return nil, fmt.Errorf("no registered model found for id %s", id)
+	}
+
 	regModel, err := serv.mapper.MapToRegisteredModel(getByIdResp.Contexts[0])
+	if err != nil {
+		return nil, err
+	}
+
+	return regModel, nil
+}
+
+func (serv *modelRegistryService) getRegisteredModelByVersionId(id string) (*openapi.RegisteredModel, error) {
+	log.Printf("Getting registered model for model version %s", id)
+
+	idAsInt, err := mapper.IdToInt64(id)
+	if err != nil {
+		return nil, err
+	}
+
+	getParentResp, err := serv.mlmdClient.GetParentContextsByContext(context.Background(), &proto.GetParentContextsByContextRequest{
+		ContextId: idAsInt,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(getParentResp.Contexts) > 1 {
+		return nil, fmt.Errorf("multiple registered models found for model version %s", id)
+	}
+
+	if len(getParentResp.Contexts) == 0 {
+		return nil, fmt.Errorf("no registered model found for model version %s", id)
+	}
+
+	regModel, err := serv.mapper.MapToRegisteredModel(getParentResp.Contexts[0])
 	if err != nil {
 		return nil, err
 	}
@@ -143,6 +194,8 @@ func (serv *modelRegistryService) GetRegisteredModelByParams(name *string, exter
 		filterQuery = fmt.Sprintf("name = \"%s\"", *name)
 	} else if externalId != nil {
 		filterQuery = fmt.Sprintf("external_id = \"%s\"", *externalId)
+	} else {
+		return nil, fmt.Errorf("invalid parameters call, supply either name or externalId")
 	}
 
 	getByParamsResp, err := serv.mlmdClient.GetContextsByType(context.Background(), &proto.GetContextsByTypeRequest{
@@ -200,26 +253,48 @@ func (serv *modelRegistryService) GetRegisteredModels(listOptions ListOptions) (
 // MODEL VERSIONS
 
 func (serv *modelRegistryService) UpsertModelVersion(modelVersion *openapi.ModelVersion, parentResourceId *string) (*openapi.ModelVersion, error) {
+	var err error
+	var existing *openapi.ModelVersion
+	var registeredModel *openapi.RegisteredModel
+
 	if modelVersion.Id == nil {
-		log.Printf("Creating model version")
+		// create
+		log.Printf("Creating new model version")
+		if parentResourceId == nil {
+			return nil, fmt.Errorf("missing registered model id, cannot create model version without registered model")
+		}
+		registeredModel, err = serv.GetRegisteredModelById(*parentResourceId)
+		if err != nil {
+			return nil, err
+		}
 	} else {
+		// update
 		log.Printf("Updating model version %s", *modelVersion.Id)
+		existing, err = serv.GetModelVersionById(*modelVersion.Id)
+		if err != nil {
+			return nil, err
+		}
+		registeredModel, err = serv.getRegisteredModelByVersionId(*modelVersion.Id)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	if parentResourceId == nil {
-		return nil, fmt.Errorf("missing registered model id, cannot create model version without registered model")
-	}
-
-	registeredModel, err := serv.GetRegisteredModelById(*parentResourceId)
-	if err != nil {
-		return nil, fmt.Errorf("not a valid registered model id: %s", *parentResourceId)
-	}
-	registeredModelIdCtxID, err := mapper.IdToInt64(*registeredModel.Id)
+	registeredModelId, err := mapper.IdToInt64(*registeredModel.Id)
 	if err != nil {
 		return nil, err
 	}
-	registeredModelName := registeredModel.Name
-	modelCtx, err := serv.mapper.MapFromModelVersion(modelVersion, *registeredModelIdCtxID, registeredModelName)
+
+	// if already existing assure the name is the same
+	if existing != nil {
+		if modelVersion.Name == nil {
+			// user did not provide it
+			// need to set it to avoid mlmd error "context name should not be empty"
+			modelVersion.Name = existing.Name
+		}
+	}
+
+	modelCtx, err := serv.mapper.MapFromModelVersion(modelVersion, *registeredModelId, registeredModel.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +313,7 @@ func (serv *modelRegistryService) UpsertModelVersion(modelVersion *openapi.Model
 		_, err = serv.mlmdClient.PutParentContexts(context.Background(), &proto.PutParentContextsRequest{
 			ParentContexts: []*proto.ParentContext{{
 				ChildId:  modelId,
-				ParentId: registeredModelIdCtxID}},
+				ParentId: registeredModelId}},
 			TransactionOptions: &proto.TransactionOptions{},
 		})
 		if err != nil {
@@ -268,8 +343,12 @@ func (serv *modelRegistryService) GetModelVersionById(id string) (*openapi.Model
 		return nil, err
 	}
 
-	if len(getByIdResp.Contexts) != 1 {
+	if len(getByIdResp.Contexts) > 1 {
 		return nil, fmt.Errorf("multiple model versions found for id %s", id)
+	}
+
+	if len(getByIdResp.Contexts) == 0 {
+		return nil, fmt.Errorf("no model version found for id %s", id)
 	}
 
 	modelVer, err := serv.mapper.MapToModelVersion(getByIdResp.Contexts[0])
@@ -278,6 +357,37 @@ func (serv *modelRegistryService) GetModelVersionById(id string) (*openapi.Model
 	}
 
 	return modelVer, nil
+}
+
+func (serv *modelRegistryService) getModelVersionByArtifactId(id string) (*openapi.ModelVersion, error) {
+	log.Printf("Getting model version for model artifact %s", id)
+
+	idAsInt, err := mapper.IdToInt64(id)
+	if err != nil {
+		return nil, err
+	}
+
+	getParentResp, err := serv.mlmdClient.GetContextsByArtifact(context.Background(), &proto.GetContextsByArtifactRequest{
+		ArtifactId: idAsInt,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(getParentResp.Contexts) > 1 {
+		return nil, fmt.Errorf("multiple model versions found for model artifact %s", id)
+	}
+
+	if len(getParentResp.Contexts) == 0 {
+		return nil, fmt.Errorf("no model version found for model artifact %s", id)
+	}
+
+	modelVersion, err := serv.mapper.MapToModelVersion(getParentResp.Contexts[0])
+	if err != nil {
+		return nil, err
+	}
+
+	return modelVersion, nil
 }
 
 func (serv *modelRegistryService) GetModelVersionByParams(versionName *string, parentResourceId *string, externalId *string) (*openapi.ModelVersion, error) {
@@ -290,6 +400,8 @@ func (serv *modelRegistryService) GetModelVersionByParams(versionName *string, p
 		filterQuery = fmt.Sprintf("name = \"%s\"", mapper.PrefixWhenOwned(idAsInt, *versionName))
 	} else if externalId != nil {
 		filterQuery = fmt.Sprintf("external_id = \"%s\"", *externalId)
+	} else {
+		return nil, fmt.Errorf("invalid parameters call, supply either (versionName and parentResourceId), or externalId")
 	}
 
 	getByParamsResp, err := serv.mlmdClient.GetContextsByType(context.Background(), &proto.GetContextsByTypeRequest{
@@ -353,17 +465,47 @@ func (serv *modelRegistryService) GetModelVersions(listOptions ListOptions, pare
 // MODEL ARTIFACTS
 
 func (serv *modelRegistryService) UpsertModelArtifact(modelArtifact *openapi.ModelArtifact, parentResourceId *string) (*openapi.ModelArtifact, error) {
+	var err error
+	var existing *openapi.ModelArtifact
+
 	if modelArtifact.Id == nil {
-		log.Printf("Creating model artifact")
+		// create
+		log.Printf("Creating new model artifact")
+		if parentResourceId == nil {
+			return nil, fmt.Errorf("missing model version id, cannot create model artifact without model version")
+		}
+		_, err = serv.GetModelVersionById(*parentResourceId)
+		if err != nil {
+			return nil, err
+		}
 	} else {
+		// update
 		log.Printf("Updating model artifact %s", *modelArtifact.Id)
+		existing, err = serv.GetModelArtifactById(*modelArtifact.Id)
+		if err != nil {
+			return nil, err
+		}
+		_, err = serv.getModelVersionByArtifactId(*modelArtifact.Id)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	idAsInt, err := mapper.IdToInt64(*parentResourceId)
+	modelVersionId, err := mapper.IdToInt64(*parentResourceId)
 	if err != nil {
 		return nil, err
 	}
-	artifact := serv.mapper.MapFromModelArtifact(*modelArtifact, idAsInt)
+
+	// if already existing assure the name is the same
+	if existing != nil {
+		if modelArtifact.Name == nil {
+			// user did not provide it
+			// need to set it to avoid mlmd error "artifact name should not be empty"
+			modelArtifact.Name = existing.Name
+		}
+	}
+
+	artifact := serv.mapper.MapFromModelArtifact(*modelArtifact, modelVersionId)
 
 	artifactsResp, err := serv.mlmdClient.PutArtifacts(context.Background(), &proto.PutArtifactsRequest{
 		Artifacts: []*proto.Artifact{artifact},
@@ -374,14 +516,10 @@ func (serv *modelRegistryService) UpsertModelArtifact(modelArtifact *openapi.Mod
 
 	// add explicit association between artifacts and model version
 	if parentResourceId != nil && modelArtifact.Id == nil {
-		modelVersionIdCtx, err := mapper.IdToInt64(*parentResourceId)
-		if err != nil {
-			return nil, err
-		}
 		attributions := []*proto.Attribution{}
 		for _, a := range artifactsResp.ArtifactIds {
 			attributions = append(attributions, &proto.Attribution{
-				ContextId:  modelVersionIdCtx,
+				ContextId:  modelVersionId,
 				ArtifactId: &a,
 			})
 		}
@@ -413,6 +551,14 @@ func (serv *modelRegistryService) GetModelArtifactById(id string) (*openapi.Mode
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	if len(artifactsResp.Artifacts) > 1 {
+		return nil, fmt.Errorf("multiple model artifacts found for id %s", id)
+	}
+
+	if len(artifactsResp.Artifacts) == 0 {
+		return nil, fmt.Errorf("no model artifact found for id %s", id)
 	}
 
 	result, err := serv.mapper.MapToModelArtifact(artifactsResp.Artifacts[0])

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -94,12 +94,10 @@ func (serv *modelRegistryService) UpsertRegisteredModel(registeredModel *openapi
 	}
 
 	// if already existing assure the name is the same
-	if existing != nil {
-		if registeredModel.Name == nil {
-			// user did not provide it
-			// need to set it to avoid mlmd error "context name should not be empty"
-			registeredModel.Name = existing.Name
-		}
+	if existing != nil && registeredModel.Name == nil {
+		// user did not provide it
+		// need to set it to avoid mlmd error "context name should not be empty"
+		registeredModel.Name = existing.Name
 	}
 
 	modelCtx, err := serv.mapper.MapFromRegisteredModel(registeredModel)
@@ -287,12 +285,10 @@ func (serv *modelRegistryService) UpsertModelVersion(modelVersion *openapi.Model
 	}
 
 	// if already existing assure the name is the same
-	if existing != nil {
-		if modelVersion.Name == nil {
-			// user did not provide it
-			// need to set it to avoid mlmd error "context name should not be empty"
-			modelVersion.Name = existing.Name
-		}
+	if existing != nil && modelVersion.Name == nil {
+		// user did not provide it
+		// need to set it to avoid mlmd error "context name should not be empty"
+		modelVersion.Name = existing.Name
 	}
 
 	modelCtx, err := serv.mapper.MapFromModelVersion(modelVersion, *registeredModelId, registeredModel.Name)

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/golang/glog"
 	"github.com/opendatahub-io/model-registry/internal/core/mapper"
 	"github.com/opendatahub-io/model-registry/internal/ml_metadata/proto"
 	"github.com/opendatahub-io/model-registry/internal/model/openapi"
@@ -83,9 +84,9 @@ func (serv *modelRegistryService) UpsertRegisteredModel(registeredModel *openapi
 	var existing *openapi.RegisteredModel
 
 	if registeredModel.Id == nil {
-		log.Printf("Creating new registered model")
+		glog.Info("Creating new registered model")
 	} else {
-		log.Printf("Updating registered model %s", *registeredModel.Id)
+		glog.Info("Updating registered model %s", *registeredModel.Id)
 		existing, err = serv.GetRegisteredModelById(*registeredModel.Id)
 		if err != nil {
 			return nil, err
@@ -125,7 +126,7 @@ func (serv *modelRegistryService) UpsertRegisteredModel(registeredModel *openapi
 }
 
 func (serv *modelRegistryService) GetRegisteredModelById(id string) (*openapi.RegisteredModel, error) {
-	log.Printf("Getting registered model %s", id)
+	glog.Info("Getting registered model %s", id)
 
 	idAsInt, err := mapper.IdToInt64(id)
 	if err != nil {
@@ -156,7 +157,7 @@ func (serv *modelRegistryService) GetRegisteredModelById(id string) (*openapi.Re
 }
 
 func (serv *modelRegistryService) getRegisteredModelByVersionId(id string) (*openapi.RegisteredModel, error) {
-	log.Printf("Getting registered model for model version %s", id)
+	glog.Info("Getting registered model for model version %s", id)
 
 	idAsInt, err := mapper.IdToInt64(id)
 	if err != nil {
@@ -187,7 +188,7 @@ func (serv *modelRegistryService) getRegisteredModelByVersionId(id string) (*ope
 }
 
 func (serv *modelRegistryService) GetRegisteredModelByParams(name *string, externalId *string) (*openapi.RegisteredModel, error) {
-	log.Printf("Getting registered model by params name=%v, externalId=%v", name, externalId)
+	glog.Info("Getting registered model by params name=%v, externalId=%v", name, externalId)
 
 	filterQuery := ""
 	if name != nil {
@@ -259,7 +260,7 @@ func (serv *modelRegistryService) UpsertModelVersion(modelVersion *openapi.Model
 
 	if modelVersion.Id == nil {
 		// create
-		log.Printf("Creating new model version")
+		glog.Info("Creating new model version")
 		if parentResourceId == nil {
 			return nil, fmt.Errorf("missing registered model id, cannot create model version without registered model")
 		}
@@ -269,7 +270,7 @@ func (serv *modelRegistryService) UpsertModelVersion(modelVersion *openapi.Model
 		}
 	} else {
 		// update
-		log.Printf("Updating model version %s", *modelVersion.Id)
+		glog.Info("Updating model version %s", *modelVersion.Id)
 		existing, err = serv.GetModelVersionById(*modelVersion.Id)
 		if err != nil {
 			return nil, err
@@ -360,7 +361,7 @@ func (serv *modelRegistryService) GetModelVersionById(id string) (*openapi.Model
 }
 
 func (serv *modelRegistryService) getModelVersionByArtifactId(id string) (*openapi.ModelVersion, error) {
-	log.Printf("Getting model version for model artifact %s", id)
+	glog.Info("Getting model version for model artifact %s", id)
 
 	idAsInt, err := mapper.IdToInt64(id)
 	if err != nil {
@@ -470,7 +471,7 @@ func (serv *modelRegistryService) UpsertModelArtifact(modelArtifact *openapi.Mod
 
 	if modelArtifact.Id == nil {
 		// create
-		log.Printf("Creating new model artifact")
+		glog.Info("Creating new model artifact")
 		if parentResourceId == nil {
 			return nil, fmt.Errorf("missing model version id, cannot create model artifact without model version")
 		}
@@ -480,7 +481,7 @@ func (serv *modelRegistryService) UpsertModelArtifact(modelArtifact *openapi.Mod
 		}
 	} else {
 		// update
-		log.Printf("Updating model artifact %s", *modelArtifact.Id)
+		glog.Info("Updating model artifact %s", *modelArtifact.Id)
 		existing, err = serv.GetModelArtifactById(*modelArtifact.Id)
 		if err != nil {
 			return nil, err

--- a/internal/core/mapper/mlmd_mapper.go
+++ b/internal/core/mapper/mlmd_mapper.go
@@ -108,7 +108,6 @@ func (m *Mapper) MapToArtifactState(oapiState *openapi.ArtifactState) *proto.Art
 }
 
 func (m *Mapper) MapFromRegisteredModel(registeredModel *openapi.RegisteredModel) (*proto.Context, error) {
-
 	var idInt *int64
 	if registeredModel.Id != nil {
 		var err error
@@ -124,10 +123,10 @@ func (m *Mapper) MapFromRegisteredModel(registeredModel *openapi.RegisteredModel
 	}
 
 	return &proto.Context{
-		Name:             registeredModel.Name,
-		TypeId:           &m.RegisteredModelTypeId,
-		ExternalId:       registeredModel.ExternalID,
 		Id:               idInt,
+		TypeId:           &m.RegisteredModelTypeId,
+		Name:             registeredModel.Name,
+		ExternalId:       registeredModel.ExternalID,
 		CustomProperties: customProps,
 	}, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/opendatahub-io/model-registry/issues/105 
Fixes https://github.com/opendatahub-io/model-registry/issues/110
Furthermore it provides some optional paramas management 

## Description
<!--- Describe your changes in detail -->
Additional improvements:
- For `Update` operations, user does not have to provide the `parentResourceId` - the implementation is going to retrieve it from the original parent association.
  - Created two internal utlities: `getModelVersionByArtifactId` and `getRegisteredModelByVersionId`
- Manage all possible failures that can happen for `create/update`, based on provided input params.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added additional test cases in `core_test` that cover the new edge cases, mostly considering possible failures.
```bash
make test-cover
```
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
