### PR TITLE
Update(Dockerfile): Use ubi9 images that contains required glibc vers…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the model-registry binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.19 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -37,7 +37,7 @@ RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 make clean model-registry
 
 # Use distroless as minimal base image to package the model-registry binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 WORKDIR /
 # copy the metadata library
 COPY --from=builder /workspace/config ./config


### PR DESCRIPTION
…ion by gqlgen

## Description
I was not able to build docker image by running `podman build -t model-registry .` command, I get error:
```
gqlgen generate
gqlgen: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by gqlgen)
gqlgen: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by gqlgen)
make: *** [Makefile:71: internal/model/graph/models_gen.go] Error 1
Error: building at STEP "RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 make clean model-registry": while running runtime: exit status 2
```

It is necessary to update base images from `ubi8` to `ubi9` that contains newer `glibc` version.

## How Has This Been Tested?
I tried to run `podman build -t model-registry .` with these changes and docker image was successfully build.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
