### PR TITLE
Create BuildListOption for REST query params

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ COPY cmd/ cmd/
 COPY api/ api/
 COPY config/ config/
 COPY internal/ internal/
+COPY pkg/ pkg/
 
 # Build
 USER root

--- a/internal/apiutils/api_utils.go
+++ b/internal/apiutils/api_utils.go
@@ -46,12 +46,12 @@ func ZeroIfNil[T any](input *T) T {
 	return *new(T)
 }
 
-func BuildListOption(pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (*api.ListOptions, error) {
+func BuildListOption(pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (api.ListOptions, error) {
 	var pageSizeInt32 *int32
 	if pageSize != "" {
 		conv, err := converter.StringToInt32(pageSize)
 		if err != nil {
-			return nil, err
+			return api.ListOptions{}, err
 		}
 		pageSizeInt32 = &conv
 	}
@@ -67,7 +67,7 @@ func BuildListOption(pageSize string, orderBy model.OrderByField, sortOrder mode
 	if nextPageToken != "" {
 		nextPageTokenParam = &nextPageToken
 	}
-	return &api.ListOptions{
+	return api.ListOptions{
 		PageSize:      pageSizeInt32,
 		OrderBy:       orderByString,
 		SortOrder:     sortOrderString,

--- a/internal/apiutils/api_utils.go
+++ b/internal/apiutils/api_utils.go
@@ -1,7 +1,9 @@
 package apiutils
 
 import (
+	"github.com/opendatahub-io/model-registry/internal/converter"
 	"github.com/opendatahub-io/model-registry/internal/ml_metadata/proto"
+	model "github.com/opendatahub-io/model-registry/internal/model/openapi"
 	"github.com/opendatahub-io/model-registry/pkg/api"
 )
 
@@ -42,4 +44,33 @@ func ZeroIfNil[T any](input *T) T {
 		return *input
 	}
 	return *new(T)
+}
+
+func BuildListOption(pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (*api.ListOptions, error) {
+	var pageSizeInt32 *int32
+	if pageSize != "" {
+		conv, err := converter.StringToInt32(pageSize)
+		if err != nil {
+			return nil, err
+		}
+		pageSizeInt32 = &conv
+	}
+	var orderByString *string
+	if orderBy != "" {
+		orderByString = (*string)(&orderBy)
+	}
+	var sortOrderString *string
+	if sortOrder != "" {
+		sortOrderString = (*string)(&sortOrder)
+	}
+	var nextPageTokenParam *string
+	if nextPageToken != "" {
+		nextPageTokenParam = &nextPageToken
+	}
+	return &api.ListOptions{
+		PageSize:      pageSizeInt32,
+		OrderBy:       orderByString,
+		SortOrder:     sortOrderString,
+		NextPageToken: nextPageTokenParam,
+	}, nil
 }

--- a/internal/server/openapi/api_model_registry_service_service.go
+++ b/internal/server/openapi/api_model_registry_service_service.go
@@ -236,7 +236,7 @@ func (s *ModelRegistryServiceAPIService) GetEnvironmentInferenceServices(ctx con
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetInferenceServices(*listOpts, &servingenvironmentId)
+	result, err := s.coreApi.GetInferenceServices(listOpts, &servingenvironmentId)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -273,7 +273,7 @@ func (s *ModelRegistryServiceAPIService) GetInferenceServiceServes(ctx context.C
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetServeModels(*listOpts, &inferenceserviceId)
+	result, err := s.coreApi.GetServeModels(listOpts, &inferenceserviceId)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -299,7 +299,7 @@ func (s *ModelRegistryServiceAPIService) GetInferenceServices(ctx context.Contex
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetInferenceServices(*listOpts, nil)
+	result, err := s.coreApi.GetInferenceServices(listOpts, nil)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -325,7 +325,7 @@ func (s *ModelRegistryServiceAPIService) GetModelArtifacts(ctx context.Context, 
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetModelArtifacts(*listOpts, nil)
+	result, err := s.coreApi.GetModelArtifacts(listOpts, nil)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -354,7 +354,7 @@ func (s *ModelRegistryServiceAPIService) GetModelVersionArtifacts(ctx context.Co
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetModelArtifacts(*listOpts, &modelversionId)
+	result, err := s.coreApi.GetModelArtifacts(listOpts, &modelversionId)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -369,7 +369,7 @@ func (s *ModelRegistryServiceAPIService) GetModelVersions(ctx context.Context, p
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetModelVersions(*listOpts, nil)
+	result, err := s.coreApi.GetModelVersions(listOpts, nil)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -398,7 +398,7 @@ func (s *ModelRegistryServiceAPIService) GetRegisteredModelVersions(ctx context.
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetModelVersions(*listOpts, &registeredmodelId)
+	result, err := s.coreApi.GetModelVersions(listOpts, &registeredmodelId)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -413,7 +413,7 @@ func (s *ModelRegistryServiceAPIService) GetRegisteredModels(ctx context.Context
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetRegisteredModels(*listOpts)
+	result, err := s.coreApi.GetRegisteredModels(listOpts)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -440,7 +440,7 @@ func (s *ModelRegistryServiceAPIService) GetServingEnvironments(ctx context.Cont
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetServingEnvironments(*listOpts)
+	result, err := s.coreApi.GetServingEnvironments(listOpts)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}

--- a/internal/server/openapi/api_model_registry_service_service.go
+++ b/internal/server/openapi/api_model_registry_service_service.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/opendatahub-io/model-registry/internal/apiutils"
 	"github.com/opendatahub-io/model-registry/internal/converter"
 	"github.com/opendatahub-io/model-registry/internal/converter/generated"
 	model "github.com/opendatahub-io/model-registry/internal/model/openapi"
@@ -231,18 +232,11 @@ func (s *ModelRegistryServiceAPIService) FindServingEnvironment(ctx context.Cont
 
 // GetEnvironmentInferenceServices - List All ServingEnvironment&#39;s InferenceServices
 func (s *ModelRegistryServiceAPIService) GetEnvironmentInferenceServices(ctx context.Context, servingenvironmentId string, name string, externalID string, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
-	orderByString := string(orderBy)
-	sortOrderString := string(sortOrder)
-	pageSizeInt32, err := converter.StringToInt32(pageSize)
+	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetInferenceServices(api.ListOptions{
-		PageSize:      &pageSizeInt32,
-		OrderBy:       &orderByString,
-		SortOrder:     &sortOrderString,
-		NextPageToken: &nextPageToken,
-	}, &servingenvironmentId)
+	result, err := s.coreApi.GetInferenceServices(*listOpts, &servingenvironmentId)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -275,18 +269,11 @@ func (s *ModelRegistryServiceAPIService) GetInferenceServiceModel(ctx context.Co
 
 // GetInferenceServiceServes - List All InferenceService&#39;s ServeModel actions
 func (s *ModelRegistryServiceAPIService) GetInferenceServiceServes(ctx context.Context, inferenceserviceId string, name string, externalID string, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
-	orderByString := string(orderBy)
-	sortOrderString := string(sortOrder)
-	pageSizeInt32, err := converter.StringToInt32(pageSize)
+	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetServeModels(api.ListOptions{
-		PageSize:      &pageSizeInt32,
-		OrderBy:       &orderByString,
-		SortOrder:     &sortOrderString,
-		NextPageToken: &nextPageToken,
-	}, &inferenceserviceId)
+	result, err := s.coreApi.GetServeModels(*listOpts, &inferenceserviceId)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -308,18 +295,11 @@ func (s *ModelRegistryServiceAPIService) GetInferenceServiceVersion(ctx context.
 
 // GetInferenceServices - List All InferenceServices
 func (s *ModelRegistryServiceAPIService) GetInferenceServices(ctx context.Context, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
-	orderByString := string(orderBy)
-	sortOrderString := string(sortOrder)
-	pageSizeInt32, err := converter.StringToInt32(pageSize)
+	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetInferenceServices(api.ListOptions{
-		PageSize:      &pageSizeInt32,
-		OrderBy:       &orderByString,
-		SortOrder:     &sortOrderString,
-		NextPageToken: &nextPageToken,
-	}, nil)
+	result, err := s.coreApi.GetInferenceServices(*listOpts, nil)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -341,18 +321,11 @@ func (s *ModelRegistryServiceAPIService) GetModelArtifact(ctx context.Context, m
 
 // GetModelArtifacts - List All ModelArtifacts
 func (s *ModelRegistryServiceAPIService) GetModelArtifacts(ctx context.Context, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
-	orderByString := string(orderBy)
-	sortOrderString := string(sortOrder)
-	pageSizeInt32, err := converter.StringToInt32(pageSize)
+	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetModelArtifacts(api.ListOptions{
-		PageSize:      &pageSizeInt32,
-		OrderBy:       &orderByString,
-		SortOrder:     &sortOrderString,
-		NextPageToken: &nextPageToken,
-	}, nil)
+	result, err := s.coreApi.GetModelArtifacts(*listOpts, nil)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -377,18 +350,11 @@ func (s *ModelRegistryServiceAPIService) GetModelVersion(ctx context.Context, mo
 func (s *ModelRegistryServiceAPIService) GetModelVersionArtifacts(ctx context.Context, modelversionId string, name string, externalID string, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	// TODO name unused
 	// TODO externalID unused
-	orderByString := string(orderBy)
-	sortOrderString := string(sortOrder)
-	pageSizeInt32, err := converter.StringToInt32(pageSize)
+	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetModelArtifacts(api.ListOptions{
-		PageSize:      &pageSizeInt32,
-		OrderBy:       &orderByString,
-		SortOrder:     &sortOrderString,
-		NextPageToken: &nextPageToken,
-	}, &modelversionId)
+	result, err := s.coreApi.GetModelArtifacts(*listOpts, &modelversionId)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -399,18 +365,11 @@ func (s *ModelRegistryServiceAPIService) GetModelVersionArtifacts(ctx context.Co
 
 // GetModelVersions - List All ModelVersions
 func (s *ModelRegistryServiceAPIService) GetModelVersions(ctx context.Context, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
-	orderByString := string(orderBy)
-	sortOrderString := string(sortOrder)
-	pageSizeInt32, err := converter.StringToInt32(pageSize)
+	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetModelVersions(api.ListOptions{
-		PageSize:      &pageSizeInt32,
-		OrderBy:       &orderByString,
-		SortOrder:     &sortOrderString,
-		NextPageToken: &nextPageToken,
-	}, nil)
+	result, err := s.coreApi.GetModelVersions(*listOpts, nil)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -435,18 +394,11 @@ func (s *ModelRegistryServiceAPIService) GetRegisteredModel(ctx context.Context,
 func (s *ModelRegistryServiceAPIService) GetRegisteredModelVersions(ctx context.Context, registeredmodelId string, name string, externalID string, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	// TODO name unused
 	// TODO externalID unused
-	orderByString := string(orderBy)
-	sortOrderString := string(sortOrder)
-	pageSizeInt32, err := converter.StringToInt32(pageSize)
+	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetModelVersions(api.ListOptions{
-		PageSize:      &pageSizeInt32,
-		OrderBy:       &orderByString,
-		SortOrder:     &sortOrderString,
-		NextPageToken: &nextPageToken,
-	}, &registeredmodelId)
+	result, err := s.coreApi.GetModelVersions(*listOpts, &registeredmodelId)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -457,18 +409,11 @@ func (s *ModelRegistryServiceAPIService) GetRegisteredModelVersions(ctx context.
 
 // GetRegisteredModels - List All RegisteredModels
 func (s *ModelRegistryServiceAPIService) GetRegisteredModels(ctx context.Context, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
-	orderByString := string(orderBy)
-	sortOrderString := string(sortOrder)
-	pageSizeInt32, err := converter.StringToInt32(pageSize)
+	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetRegisteredModels(api.ListOptions{
-		PageSize:      &pageSizeInt32,
-		OrderBy:       &orderByString,
-		SortOrder:     &sortOrderString,
-		NextPageToken: &nextPageToken,
-	})
+	result, err := s.coreApi.GetRegisteredModels(*listOpts)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -491,18 +436,11 @@ func (s *ModelRegistryServiceAPIService) GetServingEnvironment(ctx context.Conte
 
 // GetServingEnvironments - List All ServingEnvironments
 func (s *ModelRegistryServiceAPIService) GetServingEnvironments(ctx context.Context, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
-	orderByString := string(orderBy)
-	sortOrderString := string(sortOrder)
-	pageSizeInt32, err := converter.StringToInt32(pageSize)
+	listOpts, err := apiutils.BuildListOption(pageSize, orderBy, sortOrder, nextPageToken)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetServingEnvironments(api.ListOptions{
-		PageSize:      &pageSizeInt32,
-		OrderBy:       &orderByString,
-		SortOrder:     &sortOrderString,
-		NextPageToken: &nextPageToken,
-	})
+	result, err := s.coreApi.GetServingEnvironments(*listOpts)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}


### PR DESCRIPTION
Resolves #138 
as discussed with @lampajr 

## Description
Ignores unsupplied-but-golang-empty query params, and relies on defaults by gRPC; the defaults could now be overridden for alternative default-values in a single place if needed later.

## How Has This Been Tested?
After Build and a MLMD available on docker:
```
robot test/robot/UserStory.robot
curl -X 'GET' 'http://localhost:8080/api/model_registry/v1alpha1/registered_models?pageSize=47' -H 'accept: application/json'
curl -X 'GET' 'http://localhost:8080/api/model_registry/v1alpha1/registered_models' -H 'accept: application/json'
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
