### PR TITLE
Make model registry core importable as library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,19 +163,19 @@ gen: deps gen/grpc gen/openapi gen/converter gen/graph
 .PHONY: lint
 lint: gen
 	golangci-lint run main.go
-	golangci-lint run cmd/... internal/...
+	golangci-lint run cmd/... internal/... ./pkg/...
 
 .PHONY: test
 test: gen
-	go test ./internal/...
+	go test ./internal/... ./pkg/...
 
 .PHONY: test-nocache
 test-nocache: gen
-	go test ./internal/... -count=1
+	go test ./internal/... ./pkg/... -count=1
 
 .PHONY: test-cover
 test-cover: gen
-	go test ./internal/... -cover -count=1
+	go test ./internal/... ./pkg/... -cover -count=1
 
 .PHONY: run/migrate
 run/migrate: gen

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 
 	"github.com/golang/glog"
-	"github.com/opendatahub-io/model-registry/internal/core"
 	"github.com/opendatahub-io/model-registry/internal/server/openapi"
+	"github.com/opendatahub-io/model-registry/pkg/core"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"

--- a/internal/apiutils/api_utils.go
+++ b/internal/apiutils/api_utils.go
@@ -1,17 +1,11 @@
-package core
+package apiutils
 
 import (
 	"github.com/opendatahub-io/model-registry/internal/ml_metadata/proto"
+	"github.com/opendatahub-io/model-registry/pkg/api"
 )
 
-func zeroIfNil[T any](input *T) T {
-	if input != nil {
-		return *input
-	}
-	return *new(T)
-}
-
-func BuildListOperationOptions(listOptions ListOptions) (*proto.ListOperationOptions, error) {
+func BuildListOperationOptions(listOptions api.ListOptions) (*proto.ListOperationOptions, error) {
 
 	result := proto.ListOperationOptions{}
 	if listOptions.PageSize != nil {
@@ -40,4 +34,12 @@ func BuildListOperationOptions(listOptions ListOptions) (*proto.ListOperationOpt
 		}
 	}
 	return &result, nil
+}
+
+// ZeroIfNil return the zeroed value if input is a nil pointer
+func ZeroIfNil[T any](input *T) T {
+	if input != nil {
+		return *input
+	}
+	return *new(T)
 }

--- a/internal/mapper/mapper.go
+++ b/internal/mapper/mapper.go
@@ -1,4 +1,4 @@
-package core
+package mapper
 
 import (
 	"fmt"

--- a/internal/server/openapi/api_model_registry_service_service.go
+++ b/internal/server/openapi/api_model_registry_service_service.go
@@ -16,20 +16,20 @@ import (
 
 	"github.com/opendatahub-io/model-registry/internal/converter"
 	"github.com/opendatahub-io/model-registry/internal/converter/generated"
-	"github.com/opendatahub-io/model-registry/internal/core"
 	model "github.com/opendatahub-io/model-registry/internal/model/openapi"
+	"github.com/opendatahub-io/model-registry/pkg/api"
 )
 
 // ModelRegistryServiceAPIService is a service that implements the logic for the ModelRegistryServiceAPIServicer
 // This service should implement the business logic for every endpoint for the ModelRegistryServiceAPI s.coreApi.
 // Include any external packages or services that will be required by this service.
 type ModelRegistryServiceAPIService struct {
-	coreApi   core.ModelRegistryApi
+	coreApi   api.ModelRegistryApi
 	converter converter.OpenAPIConverter
 }
 
 // NewModelRegistryServiceAPIService creates a default api service
-func NewModelRegistryServiceAPIService(coreApi core.ModelRegistryApi) ModelRegistryServiceAPIServicer {
+func NewModelRegistryServiceAPIService(coreApi api.ModelRegistryApi) ModelRegistryServiceAPIServicer {
 	return &ModelRegistryServiceAPIService{
 		coreApi:   coreApi,
 		converter: &generated.OpenAPIConverterImpl{},
@@ -237,7 +237,7 @@ func (s *ModelRegistryServiceAPIService) GetEnvironmentInferenceServices(ctx con
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetInferenceServices(core.ListOptions{
+	result, err := s.coreApi.GetInferenceServices(api.ListOptions{
 		PageSize:      &pageSizeInt32,
 		OrderBy:       &orderByString,
 		SortOrder:     &sortOrderString,
@@ -281,7 +281,7 @@ func (s *ModelRegistryServiceAPIService) GetInferenceServiceServes(ctx context.C
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetServeModels(core.ListOptions{
+	result, err := s.coreApi.GetServeModels(api.ListOptions{
 		PageSize:      &pageSizeInt32,
 		OrderBy:       &orderByString,
 		SortOrder:     &sortOrderString,
@@ -314,7 +314,7 @@ func (s *ModelRegistryServiceAPIService) GetInferenceServices(ctx context.Contex
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetInferenceServices(core.ListOptions{
+	result, err := s.coreApi.GetInferenceServices(api.ListOptions{
 		PageSize:      &pageSizeInt32,
 		OrderBy:       &orderByString,
 		SortOrder:     &sortOrderString,
@@ -347,7 +347,7 @@ func (s *ModelRegistryServiceAPIService) GetModelArtifacts(ctx context.Context, 
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetModelArtifacts(core.ListOptions{
+	result, err := s.coreApi.GetModelArtifacts(api.ListOptions{
 		PageSize:      &pageSizeInt32,
 		OrderBy:       &orderByString,
 		SortOrder:     &sortOrderString,
@@ -383,7 +383,7 @@ func (s *ModelRegistryServiceAPIService) GetModelVersionArtifacts(ctx context.Co
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetModelArtifacts(core.ListOptions{
+	result, err := s.coreApi.GetModelArtifacts(api.ListOptions{
 		PageSize:      &pageSizeInt32,
 		OrderBy:       &orderByString,
 		SortOrder:     &sortOrderString,
@@ -405,7 +405,7 @@ func (s *ModelRegistryServiceAPIService) GetModelVersions(ctx context.Context, p
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetModelVersions(core.ListOptions{
+	result, err := s.coreApi.GetModelVersions(api.ListOptions{
 		PageSize:      &pageSizeInt32,
 		OrderBy:       &orderByString,
 		SortOrder:     &sortOrderString,
@@ -441,7 +441,7 @@ func (s *ModelRegistryServiceAPIService) GetRegisteredModelVersions(ctx context.
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetModelVersions(core.ListOptions{
+	result, err := s.coreApi.GetModelVersions(api.ListOptions{
 		PageSize:      &pageSizeInt32,
 		OrderBy:       &orderByString,
 		SortOrder:     &sortOrderString,
@@ -463,7 +463,7 @@ func (s *ModelRegistryServiceAPIService) GetRegisteredModels(ctx context.Context
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetRegisteredModels(core.ListOptions{
+	result, err := s.coreApi.GetRegisteredModels(api.ListOptions{
 		PageSize:      &pageSizeInt32,
 		OrderBy:       &orderByString,
 		SortOrder:     &sortOrderString,
@@ -497,7 +497,7 @@ func (s *ModelRegistryServiceAPIService) GetServingEnvironments(ctx context.Cont
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetServingEnvironments(core.ListOptions{
+	result, err := s.coreApi.GetServingEnvironments(api.ListOptions{
 		PageSize:      &pageSizeInt32,
 		OrderBy:       &orderByString,
 		SortOrder:     &sortOrderString,

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,4 +1,4 @@
-package core
+package api
 
 import "github.com/opendatahub-io/model-registry/internal/model/openapi"
 

--- a/test/bdd/mr_service_features_test.go
+++ b/test/bdd/mr_service_features_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 
 	"github.com/cucumber/godog"
-	"github.com/opendatahub-io/model-registry/internal/core"
 	"github.com/opendatahub-io/model-registry/internal/ml_metadata/proto"
 	"github.com/opendatahub-io/model-registry/internal/model/openapi"
+	"github.com/opendatahub-io/model-registry/pkg/api"
+	"github.com/opendatahub-io/model-registry/pkg/core"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"google.golang.org/grpc"
@@ -67,7 +68,7 @@ func iHaveAConnectionToMR(ctx context.Context) (context.Context, error) {
 }
 
 func iStoreARegisteredModelWithNameAndAChildModelVersionWithNameAndAChildArtifactWithUri(ctx context.Context, registedModelName, modelVersionName, artifactURI string) error {
-	service, ok := ctx.Value(svcLayerCtxKey{}).(core.ModelRegistryApi)
+	service, ok := ctx.Value(svcLayerCtxKey{}).(api.ModelRegistryApi)
 	if !ok {
 		return fmt.Errorf("not found service layer connection in godog context")
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/opendatahub-io/model-registry/issues/125

## Description
<!--- Describe your changes in detail -->

Moved part of the `core` package into `pkg` folder, i.e., making it importable from other libraries.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Nothing changed from implementation point of view.

```bash
make test
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
