### PR TITLE
Fix docker compose setup

### DIFF
--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/opendatahub-io/model-registry/internal/core"
@@ -28,12 +29,15 @@ hostname and port where it listens.'`,
 )
 
 func runProxyServer(cmd *cobra.Command, args []string) error {
-	glog.Infof("proxy server started at %s:%v", cfg.Hostname, cfg.Port)
+	glog.Infof("Proxy server started at %s:%v", cfg.Hostname, cfg.Port)
+
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
 
 	mlmdAddr := fmt.Sprintf("%s:%d", proxyCfg.MLMDHostname, proxyCfg.MLMDPort)
-	glog.Infof("MLMD server %s", mlmdAddr)
+	glog.Infof("Connecting to MLMD server %s..", mlmdAddr)
 	conn, err := grpc.DialContext(
-		context.Background(),
+		ctxTimeout,
 		mlmdAddr,
 		grpc.WithReturnConnectionError(),
 		grpc.WithBlock(),
@@ -44,6 +48,8 @@ func runProxyServer(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer conn.Close()
+	glog.Infof("Connected to MLMD server")
+
 	service, err := core.NewModelRegistryService(conn)
 	if err != nil {
 		log.Fatalf("Error creating core service: %v", err)

--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -1,10 +1,10 @@
 version: '3'
 services:
-  ml-metadata:
+  mlmd-server:
     image: gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0
     container_name: mlmd-server
     ports:
-      - "8080:8080"
+      - "9090:8080"
     environment:
       - METADATA_STORE_SERVER_CONFIG_FILE=/tmp/shared/conn_config.pb
     volumes:
@@ -13,8 +13,8 @@ services:
     build: 
       context: .
       dockerfile: Dockerfile
+    command: ["proxy", "--mlmd-hostname", "localhost", "--mlmd-port", "9090"]
     container_name: model-registry
-    ports:
-      - "8081:8080"
+    network_mode: host
     depends_on: 
-      - ml-metadata
+      - mlmd-server

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,19 +1,18 @@
 version: '3'
 services:
-  ml-metadata:
+  mlmd-server:
     image: gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0
     container_name: mlmd-server
     ports:
-      - "8080:8080"
+      - "9090:8080"
     environment:
       - METADATA_STORE_SERVER_CONFIG_FILE=/tmp/shared/conn_config.pb
     volumes:
       - ./test/config/ml-metadata:/tmp/shared
   model-registry:
     image: quay.io/opendatahub/model-registry:latest
-    command: ["proxy"]
+    command: ["proxy", "--mlmd-hostname", "localhost", "--mlmd-port", "9090"]
     container_name: model-registry
-    ports:
-      - "8081:8080"
+    network_mode: host
     depends_on: 
-      - ml-metadata
+      - mlmd-server


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix docker compose setup making the proxy accessible from local environment.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Running `docker compose -f docker-compose.yaml up`:

```bash
❯ docker compose -f docker-compose.yaml up
[+] Running 2/2
 ✔ Container mlmd-server     Created                                                                                                                                                                                                                        0.0s 
 ✔ Container model-registry  Recreated                                                                                                                                                                                                                      0.1s 
Attaching to mlmd-server, model-registry
mlmd-server     | WARNING: Logging before InitGoogleLogging() is written to STDERR
mlmd-server     | I1113 15:40:34.877207     7 metadata_store_server_main.cc:577] Server listening on 0.0.0.0:8080
model-registry  | I1113 15:40:35.008906       1 proxy.go:31] proxy server started at localhost:8080
model-registry  | I1113 15:40:35.008978       1 proxy.go:34] MLMD server localhost:9090
model-registry  | 2023/11/13 15:40:44 "GET http://localhost:8080/api/model_registry/v1alpha1/model_versions?pageSize=100&orderBy=ID&sortOrder=DESC&nextPageToken=IkhlbGxvLCB3b3JsZC4i HTTP/1.1" from 127.0.0.1:40616 - 200 56B in 3.046919ms
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
