### PR TITLE
Revert "Update(Dockerfile): Use ubi9 images that contains required gl…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the model-registry binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -38,7 +38,7 @@ RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 make clean model-registry
 
 # Use distroless as minimal base image to package the model-registry binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
 WORKDIR /
 # copy the metadata library
 COPY --from=builder /workspace/config ./config


### PR DESCRIPTION
…ibc version by gqlgen (#135)"

This reverts commit 6595e84e5c8f342321f97d8cfae63e75997020d3.

## Description
We can go back to ubi8 images that are sufficient for image building.

## How Has This Been Tested?
```
docker build -t model-registry .
```

## Merge criteria:
- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
