### PR TITLE
Fix core library issue

### DIFF
--- a/internal/converter/mlmd_openapi_converter_util.go
+++ b/internal/converter/mlmd_openapi_converter_util.go
@@ -78,10 +78,10 @@ func MapNameFromOwned(source *string) *string {
 // MODEL ARTIFACT
 
 func MapArtifactType(source *proto.Artifact) (string, error) {
-	if *source.Type == ModelArtifactTypeName {
+	if source.Type != nil && *source.Type == ModelArtifactTypeName {
 		return "model-artifact", nil
 	}
-	return "", fmt.Errorf("invalid artifact type found")
+	return "", fmt.Errorf("invalid artifact type found: %v", source.Type)
 }
 
 func MapMLMDModelArtifactState(source *proto.Artifact_State) *openapi.ArtifactState {

--- a/internal/mapper/mapper.go
+++ b/internal/mapper/mapper.go
@@ -131,27 +131,15 @@ func (m *Mapper) MapFromServeModel(serveModel *openapi.ServeModel, inferenceServ
 // Utilities for MLMD --> OpenAPI mapping, make use of generated Converters
 
 func (m *Mapper) MapToRegisteredModel(ctx *proto.Context) (*openapi.RegisteredModel, error) {
-	if ctx.GetTypeId() != m.RegisteredModelTypeId {
-		return nil, fmt.Errorf("invalid TypeId, expected %d but received %d", m.RegisteredModelTypeId, ctx.GetTypeId())
-	}
-
-	return m.MLMDConverter.ConvertRegisteredModel(ctx)
+	return mapTo(ctx, m.RegisteredModelTypeId, m.MLMDConverter.ConvertRegisteredModel)
 }
 
 func (m *Mapper) MapToModelVersion(ctx *proto.Context) (*openapi.ModelVersion, error) {
-	if ctx.GetTypeId() != m.ModelVersionTypeId {
-		return nil, fmt.Errorf("invalid TypeId, expected %d but received %d", m.ModelVersionTypeId, ctx.GetTypeId())
-	}
-
-	return m.MLMDConverter.ConvertModelVersion(ctx)
+	return mapTo(ctx, m.ModelVersionTypeId, m.MLMDConverter.ConvertModelVersion)
 }
 
-func (m *Mapper) MapToModelArtifact(artifact *proto.Artifact) (*openapi.ModelArtifact, error) {
-	if artifact.GetTypeId() != m.ModelArtifactTypeId {
-		return nil, fmt.Errorf("invalid TypeId, expected %d but received %d", m.ModelArtifactTypeId, artifact.GetTypeId())
-	}
-
-	return m.MLMDConverter.ConvertModelArtifact(artifact)
+func (m *Mapper) MapToModelArtifact(art *proto.Artifact) (*openapi.ModelArtifact, error) {
+	return mapTo(art, m.ModelArtifactTypeId, m.MLMDConverter.ConvertModelArtifact)
 }
 
 func (m *Mapper) MapToServingEnvironment(ctx *proto.Context) (*openapi.ServingEnvironment, error) {
@@ -162,8 +150,8 @@ func (m *Mapper) MapToInferenceService(ctx *proto.Context) (*openapi.InferenceSe
 	return mapTo(ctx, m.InferenceServiceTypeId, m.MLMDConverter.ConvertInferenceService)
 }
 
-func (m *Mapper) MapToServeModel(ctx *proto.Execution) (*openapi.ServeModel, error) {
-	return mapTo(ctx, m.ServeModelTypeId, m.MLMDConverter.ConvertServeModel)
+func (m *Mapper) MapToServeModel(ex *proto.Execution) (*openapi.ServeModel, error) {
+	return mapTo(ex, m.ServeModelTypeId, m.MLMDConverter.ConvertServeModel)
 }
 
 type getTypeIder interface {

--- a/internal/mapper/mapper_test.go
+++ b/internal/mapper/mapper_test.go
@@ -1,0 +1,147 @@
+package mapper
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/opendatahub-io/model-registry/internal/ml_metadata/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	invalidTypeId            = int64(9999)
+	registeredModelTypeId    = int64(1)
+	modelVersionTypeId       = int64(2)
+	modelArtifactTypeId      = int64(3)
+	servingEnvironmentTypeId = int64(4)
+	inferenceServiceTypeId   = int64(5)
+	serveModelTypeId         = int64(6)
+)
+
+func setup(t *testing.T) (*assert.Assertions, *Mapper) {
+	return assert.New(t), NewMapper(
+		registeredModelTypeId,
+		modelVersionTypeId,
+		modelArtifactTypeId,
+		servingEnvironmentTypeId,
+		inferenceServiceTypeId,
+		serveModelTypeId,
+	)
+}
+
+func TestMapToRegisteredModel(t *testing.T) {
+	assertion, m := setup(t)
+	_, err := m.MapToRegisteredModel(&proto.Context{
+		TypeId: of(registeredModelTypeId),
+	})
+	assertion.Nil(err)
+}
+
+func TestMapToRegisteredModelInvalid(t *testing.T) {
+	assertion, m := setup(t)
+	_, err := m.MapToRegisteredModel(&proto.Context{
+		TypeId: of(invalidTypeId),
+	})
+	assertion.NotNil(err)
+	assertion.Equal(fmt.Sprintf("invalid TypeId, expected %d but received %d", registeredModelTypeId, invalidTypeId), err.Error())
+}
+
+func TestMapToModelVersion(t *testing.T) {
+	assertion, m := setup(t)
+	_, err := m.MapToModelVersion(&proto.Context{
+		TypeId: of(modelVersionTypeId),
+	})
+	assertion.Nil(err)
+}
+
+func TestMapToModelVersionInvalid(t *testing.T) {
+	assertion, m := setup(t)
+	_, err := m.MapToModelVersion(&proto.Context{
+		TypeId: of(invalidTypeId),
+	})
+	assertion.NotNil(err)
+	assertion.Equal(fmt.Sprintf("invalid TypeId, expected %d but received %d", modelVersionTypeId, invalidTypeId), err.Error())
+}
+
+func TestMapToModelArtifact(t *testing.T) {
+	assertion, m := setup(t)
+	_, err := m.MapToModelArtifact(&proto.Artifact{
+		TypeId: of(modelArtifactTypeId),
+		Type:   of("odh.ModelArtifact"),
+	})
+	assertion.Nil(err)
+}
+
+func TestMapToModelArtifactMissingType(t *testing.T) {
+	assertion, m := setup(t)
+	_, err := m.MapToModelArtifact(&proto.Artifact{
+		TypeId: of(modelArtifactTypeId),
+	})
+	assertion.NotNil(err)
+	assertion.Equal("error setting field ArtifactType: invalid artifact type found: <nil>", err.Error())
+}
+
+func TestMapToModelArtifactInvalid(t *testing.T) {
+	assertion, m := setup(t)
+	_, err := m.MapToModelArtifact(&proto.Artifact{
+		TypeId: of(invalidTypeId),
+	})
+	assertion.NotNil(err)
+	assertion.Equal(fmt.Sprintf("invalid TypeId, expected %d but received %d", modelArtifactTypeId, invalidTypeId), err.Error())
+}
+
+func TestMapToServingEnvironment(t *testing.T) {
+	assertion, m := setup(t)
+	_, err := m.MapToServingEnvironment(&proto.Context{
+		TypeId: of(servingEnvironmentTypeId),
+	})
+	assertion.Nil(err)
+}
+
+func TestMapToServingEnvironmentInvalid(t *testing.T) {
+	assertion, m := setup(t)
+	_, err := m.MapToServingEnvironment(&proto.Context{
+		TypeId: of(invalidTypeId),
+	})
+	assertion.NotNil(err)
+	assertion.Equal(fmt.Sprintf("invalid TypeId, expected %d but received %d", servingEnvironmentTypeId, invalidTypeId), err.Error())
+}
+
+func TestMapToInferenceService(t *testing.T) {
+	assertion, m := setup(t)
+	_, err := m.MapToInferenceService(&proto.Context{
+		TypeId: of(inferenceServiceTypeId),
+	})
+	assertion.Nil(err)
+}
+
+func TestMapToInferenceServiceInvalid(t *testing.T) {
+	assertion, m := setup(t)
+	_, err := m.MapToInferenceService(&proto.Context{
+		TypeId: of(invalidTypeId),
+	})
+	assertion.NotNil(err)
+	assertion.Equal(fmt.Sprintf("invalid TypeId, expected %d but received %d", inferenceServiceTypeId, invalidTypeId), err.Error())
+}
+
+func TestMapToServeModel(t *testing.T) {
+	assertion, m := setup(t)
+	_, err := m.MapToServeModel(&proto.Execution{
+		TypeId: of(serveModelTypeId),
+	})
+	assertion.Nil(err)
+}
+
+func TestMapToServeModelInvalid(t *testing.T) {
+	assertion, m := setup(t)
+	_, err := m.MapToServeModel(&proto.Execution{
+		TypeId: of(invalidTypeId),
+	})
+	assertion.NotNil(err)
+	assertion.Equal(fmt.Sprintf("invalid TypeId, expected %d but received %d", serveModelTypeId, invalidTypeId), err.Error())
+}
+
+// of returns a pointer to the provided literal/const input
+func of[E any](e E) *E {
+	return &e
+}

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -285,8 +285,12 @@ func (serv *modelRegistryService) GetRegisteredModelByParams(name *string, exter
 		return nil, err
 	}
 
-	if len(getByParamsResp.Contexts) != 1 {
-		return nil, fmt.Errorf("multiple registered models found for name=%v, externalId=%v", *name, *externalId)
+	if len(getByParamsResp.Contexts) > 1 {
+		return nil, fmt.Errorf("multiple registered models found for name=%v, externalId=%v", apiutils.ZeroIfNil(name), apiutils.ZeroIfNil(externalId))
+	}
+
+	if len(getByParamsResp.Contexts) == 0 {
+		return nil, fmt.Errorf("no registered models found for name=%v, externalId=%v", apiutils.ZeroIfNil(name), apiutils.ZeroIfNil(externalId))
 	}
 
 	regModel, err := serv.mapper.MapToRegisteredModel(getByParamsResp.Contexts[0])
@@ -506,8 +510,12 @@ func (serv *modelRegistryService) GetModelVersionByParams(versionName *string, p
 		return nil, err
 	}
 
-	if len(getByParamsResp.Contexts) != 1 {
+	if len(getByParamsResp.Contexts) > 1 {
 		return nil, fmt.Errorf("multiple model versions found for versionName=%v, parentResourceId=%v, externalId=%v", apiutils.ZeroIfNil(versionName), apiutils.ZeroIfNil(parentResourceId), apiutils.ZeroIfNil(externalId))
+	}
+
+	if len(getByParamsResp.Contexts) == 0 {
+		return nil, fmt.Errorf("no model versions found for versionName=%v, parentResourceId=%v, externalId=%v", apiutils.ZeroIfNil(versionName), apiutils.ZeroIfNil(parentResourceId), apiutils.ZeroIfNil(externalId))
 	}
 
 	modelVer, err := serv.mapper.MapToModelVersion(getByParamsResp.Contexts[0])
@@ -848,8 +856,12 @@ func (serv *modelRegistryService) GetServingEnvironmentByParams(name *string, ex
 		return nil, err
 	}
 
-	if len(getByParamsResp.Contexts) != 1 {
-		return nil, fmt.Errorf("could not find exactly one Context matching criteria: %v", getByParamsResp.Contexts)
+	if len(getByParamsResp.Contexts) > 1 {
+		return nil, fmt.Errorf("multiple serving environments found for name=%v, externalId=%v", apiutils.ZeroIfNil(name), apiutils.ZeroIfNil(externalId))
+	}
+
+	if len(getByParamsResp.Contexts) == 0 {
+		return nil, fmt.Errorf("no serving environments found for name=%v, externalId=%v", apiutils.ZeroIfNil(name), apiutils.ZeroIfNil(externalId))
 	}
 
 	openapiModel, err := serv.mapper.MapToServingEnvironment(getByParamsResp.Contexts[0])
@@ -1052,8 +1064,12 @@ func (serv *modelRegistryService) GetInferenceServiceByParams(name *string, pare
 		return nil, err
 	}
 
-	if len(getByParamsResp.Contexts) != 1 {
-		return nil, fmt.Errorf("multiple InferenceServices found for name=%v, parentResourceId=%v, externalId=%v", apiutils.ZeroIfNil(name), apiutils.ZeroIfNil(parentResourceId), apiutils.ZeroIfNil(externalId))
+	if len(getByParamsResp.Contexts) > 1 {
+		return nil, fmt.Errorf("multiple inference services found for versionName=%v, parentResourceId=%v, externalId=%v", apiutils.ZeroIfNil(name), apiutils.ZeroIfNil(parentResourceId), apiutils.ZeroIfNil(externalId))
+	}
+
+	if len(getByParamsResp.Contexts) == 0 {
+		return nil, fmt.Errorf("no inference services found for versionName=%v, parentResourceId=%v, externalId=%v", apiutils.ZeroIfNil(name), apiutils.ZeroIfNil(parentResourceId), apiutils.ZeroIfNil(externalId))
 	}
 
 	toReturn, err := serv.mapper.MapToInferenceService(getByParamsResp.Contexts[0])

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -89,6 +89,7 @@ func NewModelRegistryService(cc grpc.ClientConnInterface) (api.ModelRegistryApi,
 				"registered_model_id": proto.PropertyType_INT,
 				// same information tracked using ParentContext association
 				"serving_environment_id": proto.PropertyType_INT,
+				"runtime":                proto.PropertyType_STRING,
 			},
 		},
 	}
@@ -99,7 +100,6 @@ func NewModelRegistryService(cc grpc.ClientConnInterface) (api.ModelRegistryApi,
 			Properties: map[string]proto.PropertyType{
 				"description":      proto.PropertyType_STRING,
 				"model_version_id": proto.PropertyType_INT,
-				"runtime":          proto.PropertyType_STRING,
 			},
 		},
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Trying to showcase the core library usage I identified some issues, this PR aims to fix them.

## Description
Summary:
- Manage error for `*ByParams` operation in a uniform way avoiding `nil` dereference.
- Fix `runtime` movement under `InferenceService` obj related to https://github.com/opendatahub-io/model-registry/issues/131 where it was wrongly created on `ServeModel` + added test to ensure correct mapping.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```bash
make test
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
