### PR TITLE
Fix GetModelArtifactByParams when no results

### DIFF
--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -692,9 +692,15 @@ func (serv *modelRegistryService) GetModelArtifactByParams(artifactName *string,
 	if err != nil {
 		return nil, err
 	}
+
 	if len(artifactsResponse.Artifacts) > 1 {
-		return nil, fmt.Errorf("more than an artifact detected matching criteria: %v", artifactsResponse.Artifacts)
+		return nil, fmt.Errorf("multiple model artifacts found for artifactName=%v, parentResourceId=%v, externalId=%v", apiutils.ZeroIfNil(artifactName), apiutils.ZeroIfNil(parentResourceId), apiutils.ZeroIfNil(externalId))
 	}
+
+	if len(artifactsResponse.Artifacts) == 0 {
+		return nil, fmt.Errorf("no model artifacts found for artifactName=%v, parentResourceId=%v, externalId=%v", apiutils.ZeroIfNil(artifactName), apiutils.ZeroIfNil(parentResourceId), apiutils.ZeroIfNil(externalId))
+	}
+
 	artifact0 = artifactsResponse.Artifacts[0]
 
 	result, err := serv.mapper.MapToModelArtifact(artifact0)
@@ -1065,11 +1071,11 @@ func (serv *modelRegistryService) GetInferenceServiceByParams(name *string, pare
 	}
 
 	if len(getByParamsResp.Contexts) > 1 {
-		return nil, fmt.Errorf("multiple inference services found for versionName=%v, parentResourceId=%v, externalId=%v", apiutils.ZeroIfNil(name), apiutils.ZeroIfNil(parentResourceId), apiutils.ZeroIfNil(externalId))
+		return nil, fmt.Errorf("multiple inference services found for name=%v, parentResourceId=%v, externalId=%v", apiutils.ZeroIfNil(name), apiutils.ZeroIfNil(parentResourceId), apiutils.ZeroIfNil(externalId))
 	}
 
 	if len(getByParamsResp.Contexts) == 0 {
-		return nil, fmt.Errorf("no inference services found for versionName=%v, parentResourceId=%v, externalId=%v", apiutils.ZeroIfNil(name), apiutils.ZeroIfNil(parentResourceId), apiutils.ZeroIfNil(externalId))
+		return nil, fmt.Errorf("no inference services found for name=%v, parentResourceId=%v, externalId=%v", apiutils.ZeroIfNil(name), apiutils.ZeroIfNil(parentResourceId), apiutils.ZeroIfNil(externalId))
 	}
 
 	toReturn, err := serv.mapper.MapToInferenceService(getByParamsResp.Contexts[0])

--- a/pkg/core/core_test.go
+++ b/pkg/core/core_test.go
@@ -419,6 +419,18 @@ func TestGetRegisteredModelById(t *testing.T) {
 	assertion.Equal(*registeredModel.CustomProperties, *getModelById.CustomProperties, "saved model custom props should match the original one")
 }
 
+func TestGetRegisteredModelByParamsWithNoResults(t *testing.T) {
+	assertion, conn, _, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	_, err := service.GetRegisteredModelByParams(of("not-present"), nil)
+	assertion.NotNil(err)
+	assertion.Equal("no registered models found for name=not-present, externalId=", err.Error())
+}
+
 func TestGetRegisteredModelByParamsName(t *testing.T) {
 	assertion, conn, _, teardown := setup(t)
 	defer teardown(t)
@@ -909,6 +921,20 @@ func TestGetModelVersionById(t *testing.T) {
 	assertion.Equal(fmt.Sprintf("%s:%s", registeredModelId, *getById.Name), *ctx.Name, "saved model name should match the provided one")
 	assertion.Equal(*getById.ExternalID, *modelVersion.ExternalID, "saved external id should match the provided one")
 	assertion.Equal(*(*getById.CustomProperties)["author"].MetadataStringValue.StringValue, author, "saved author custom property should match the provided one")
+}
+
+func TestGetModelVersionByParamsWithNoResults(t *testing.T) {
+	assertion, conn, _, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	registeredModelId := registerModel(assertion, service, nil, nil)
+
+	_, err := service.GetModelVersionByParams(of("not-present"), &registeredModelId, nil)
+	assertion.NotNil(err)
+	assertion.Equal("no model versions found for versionName=not-present, parentResourceId=1, externalId=", err.Error())
 }
 
 func TestGetModelVersionByParamsName(t *testing.T) {
@@ -1439,6 +1465,20 @@ func TestGetModelArtifactByEmptyParams(t *testing.T) {
 	assertion.Equal("invalid parameters call, supply either (artifactName and parentResourceId), or externalId", err.Error())
 }
 
+func TestGetModelArtifactByParamsWithNoResults(t *testing.T) {
+	assertion, conn, _, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	modelVersionId := registerModelVersion(assertion, service, nil, nil, nil, nil)
+
+	_, err := service.GetModelArtifactByParams(of("not-present"), &modelVersionId, nil)
+	assertion.NotNil(err)
+	assertion.Equal("no model artifacts found for artifactName=not-present, parentResourceId=2, externalId=", err.Error())
+}
+
 func TestGetModelArtifacts(t *testing.T) {
 	assertion, conn, _, teardown := setup(t)
 	defer teardown(t)
@@ -1700,6 +1740,18 @@ func TestGetServingEnvironmentById(t *testing.T) {
 	assertion.Equal(*eut.Name, *getEntityById.Name, "saved name should match the original one")
 	assertion.Equal(*eut.ExternalID, *getEntityById.ExternalID, "saved external id should match the original one")
 	assertion.Equal(*eut.CustomProperties, *getEntityById.CustomProperties, "saved custom props should match the original one")
+}
+
+func TestGetServingEnvironmentByParamsWithNoResults(t *testing.T) {
+	assertion, conn, _, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	_, err := service.GetServingEnvironmentByParams(of("not-present"), nil)
+	assertion.NotNil(err)
+	assertion.Equal("no serving environments found for name=not-present, externalId=", err.Error())
 }
 
 func TestGetServingEnvironmentByParamsName(t *testing.T) {
@@ -2306,6 +2358,20 @@ func TestGetModelVersionByInferenceServiceId(t *testing.T) {
 	getVModel, err = service.GetModelVersionByInferenceService(*createdEntity.Id)
 	assertion.Nilf(err, "error getting using id %d", *createdEntityId)
 	assertion.Equal(createdVersion1Id, *getVModel.Id, "returned id shall be the specified one")
+}
+
+func TestGetInferenceServiceByParamsWithNoResults(t *testing.T) {
+	assertion, conn, _, teardown := setup(t)
+	defer teardown(t)
+
+	// create mode registry service
+	service := initModelRegistryService(assertion, conn)
+
+	parentResourceId := registerServingEnvironment(assertion, service, nil, nil)
+
+	_, err := service.GetInferenceServiceByParams(of("not-present"), &parentResourceId, nil)
+	assertion.NotNil(err)
+	assertion.Equal("no inference services found for name=not-present, parentResourceId=1, externalId=", err.Error())
 }
 
 func TestGetInferenceServiceByParamsName(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/opendatahub-io/model-registry/issues/164

## Description
<!--- Describe your changes in detail -->
As per references issue, manage the case when no results are found during `GetModelArtifactByParams`.
Furthermore added more tests ensuring the same behavior is expected on all other `*ByParams` operations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```bash
make test
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
