### PR TITLE
python client: improve ci

### DIFF
--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -57,6 +57,16 @@ jobs:
           pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
           nox --version
 
+      - name: Lint
+        working-directory: clients/python
+        if: matrix.session == 'tests'
+        run: |
+          nox --python=${{ matrix.python }} -s lint
+          nox --python=${{ matrix.python }} -s mypy || failure=true
+          if [[ -n $failure ]]; then
+            echo "::error title='mypy failure'::Check the logs for more details"
+          fi
+
       - name: Run Nox
         working-directory: clients/python
         run: |

--- a/clients/python/noxfile.py
+++ b/clients/python/noxfile.py
@@ -7,7 +7,6 @@ from textwrap import dedent
 
 import nox
 
-
 try:
     from nox_poetry import Session, session
 except ImportError:
@@ -27,6 +26,22 @@ nox.options.sessions = (
     "tests",
     "docs-build",
 )
+
+
+@session(python=python_versions)
+def lint(session: Session) -> None:
+    """lint using ruff and mypy"""
+    session.install(".", "ruff")
+
+    session.run("ruff", "check", "src")
+
+
+@session
+def mypy(session: Session) -> None:
+    """lint using ruff and mypy"""
+    session.install(".", "mypy")
+
+    session.run("mypy", "src")
 
 
 @session(python=python_versions)

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -38,6 +38,7 @@ build-backend = "poetry.core.masonry.api"
 line-length = 119
 
 [tool.ruff]
+target-version = "py39"
 ignore = ["E501"]
 
 [tool.ruff.mccabe]


### PR DESCRIPTION
- improve CI by adding a linting step with ruff and mypy. The latter allows for failure, but adds an error message to the workflow status page
- add target-version to ruff config

ideally running ruff linting as part of CI should avoid hitting issues like the ones encountered in #168 