### PR TITLE
Add autogenerated type asserts for new states

### DIFF
--- a/internal/server/openapi/type_asserts.go
+++ b/internal/server/openapi/type_asserts.go
@@ -287,6 +287,16 @@ func AssertInferenceServiceListConstraints(obj model.InferenceServiceList) error
 	return nil
 }
 
+// AssertInferenceServiceStateRequired checks if the required fields are not zero-ed
+func AssertInferenceServiceStateRequired(obj model.InferenceServiceState) error {
+	return nil
+}
+
+// AssertInferenceServiceStateConstraints checks if the values respects the defined constraints
+func AssertInferenceServiceStateConstraints(obj model.InferenceServiceState) error {
+	return nil
+}
+
 // AssertInferenceServiceUpdateRequired checks if the required fields are not zero-ed
 func AssertInferenceServiceUpdateRequired(obj model.InferenceServiceUpdate) error {
 	return nil
@@ -487,6 +497,16 @@ func AssertModelVersionListConstraints(obj model.ModelVersionList) error {
 	return nil
 }
 
+// AssertModelVersionStateRequired checks if the required fields are not zero-ed
+func AssertModelVersionStateRequired(obj model.ModelVersionState) error {
+	return nil
+}
+
+// AssertModelVersionStateConstraints checks if the values respects the defined constraints
+func AssertModelVersionStateConstraints(obj model.ModelVersionState) error {
+	return nil
+}
+
 // AssertModelVersionUpdateRequired checks if the required fields are not zero-ed
 func AssertModelVersionUpdateRequired(obj model.ModelVersionUpdate) error {
 	return nil
@@ -550,6 +570,16 @@ func AssertRegisteredModelListRequired(obj model.RegisteredModelList) error {
 
 // AssertRegisteredModelListConstraints checks if the values respects the defined constraints
 func AssertRegisteredModelListConstraints(obj model.RegisteredModelList) error {
+	return nil
+}
+
+// AssertRegisteredModelStateRequired checks if the required fields are not zero-ed
+func AssertRegisteredModelStateRequired(obj model.RegisteredModelState) error {
+	return nil
+}
+
+// AssertRegisteredModelStateConstraints checks if the values respects the defined constraints
+func AssertRegisteredModelStateConstraints(obj model.RegisteredModelState) error {
 	return nil
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Followup https://github.com/opendatahub-io/model-registry/pull/185, regenerate proxy server to autogenerate type asserts for the new `state` fields.

Re-generated using:
```
make gen/openapi-server
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
make test
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
