### PR TITLE
Override not editable fields during updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 model-registry
 metadata.sqlite.db
 vendor
+coverage.txt
 
 # Robot Framework files
 log.html

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ bin/golangci-lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(PROJECT_BIN) v1.54.2
 
 bin/goverter:
-	GOBIN=$(PROJECT_PATH)/bin go install github.com/jmattheis/goverter/cmd/goverter@v1.0.0
+	GOBIN=$(PROJECT_PATH)/bin go install github.com/jmattheis/goverter/cmd/goverter@v1.1.1
 
 OPENAPI_GENERATOR ?= ${PROJECT_BIN}/openapi-generator-cli
 NPM ?= "$(shell which npm)"

--- a/internal/converter/generated/openapi_converter.gen.go
+++ b/internal/converter/generated/openapi_converter.gen.go
@@ -619,16 +619,6 @@ func (c *OpenAPIConverterImpl) OverrideNotEditableForModelVersion(source convert
 		pString2 = &xstring
 	}
 	openapiModelVersion.Name = pString2
-	var pOpenapiModelVersionState *openapi.ModelVersionState
-	if source.Existing != nil {
-		pOpenapiModelVersionState = source.Existing.State
-	}
-	var pOpenapiModelVersionState2 *openapi.ModelVersionState
-	if pOpenapiModelVersionState != nil {
-		openapiModelVersionState := openapi.ModelVersionState(*pOpenapiModelVersionState)
-		pOpenapiModelVersionState2 = &openapiModelVersionState
-	}
-	openapiModelVersion.State = pOpenapiModelVersionState2
 	return openapiModelVersion, nil
 }
 func (c *OpenAPIConverterImpl) OverrideNotEditableForRegisteredModel(source converter.OpenapiUpdateWrapper[openapi.RegisteredModel]) (openapi.RegisteredModel, error) {
@@ -643,16 +633,6 @@ func (c *OpenAPIConverterImpl) OverrideNotEditableForRegisteredModel(source conv
 		pString2 = &xstring
 	}
 	openapiRegisteredModel.Name = pString2
-	var pOpenapiRegisteredModelState *openapi.RegisteredModelState
-	if source.Existing != nil {
-		pOpenapiRegisteredModelState = source.Existing.State
-	}
-	var pOpenapiRegisteredModelState2 *openapi.RegisteredModelState
-	if pOpenapiRegisteredModelState != nil {
-		openapiRegisteredModelState := openapi.RegisteredModelState(*pOpenapiRegisteredModelState)
-		pOpenapiRegisteredModelState2 = &openapiRegisteredModelState
-	}
-	openapiRegisteredModel.State = pOpenapiRegisteredModelState2
 	return openapiRegisteredModel, nil
 }
 func (c *OpenAPIConverterImpl) OverrideNotEditableForServeModel(source converter.OpenapiUpdateWrapper[openapi.ServeModel]) (openapi.ServeModel, error) {

--- a/internal/converter/generated/openapi_converter.gen.go
+++ b/internal/converter/generated/openapi_converter.gen.go
@@ -2,7 +2,10 @@
 
 package generated
 
-import openapi "github.com/opendatahub-io/model-registry/pkg/openapi"
+import (
+	converter "github.com/opendatahub-io/model-registry/internal/converter"
+	openapi "github.com/opendatahub-io/model-registry/pkg/openapi"
+)
 
 type OpenAPIConverterImpl struct{}
 
@@ -548,6 +551,146 @@ func (c *OpenAPIConverterImpl) ConvertServingEnvironmentUpdate(source *openapi.S
 		pOpenapiServingEnvironment = &openapiServingEnvironment
 	}
 	return pOpenapiServingEnvironment, nil
+}
+func (c *OpenAPIConverterImpl) OverrideNotEditableForInferenceService(source converter.OpenapiUpdateWrapper[openapi.InferenceService]) (openapi.InferenceService, error) {
+	openapiInferenceService := converter.InitInferenceServiceWithUpdate(source)
+	var pString *string
+	if source.Existing != nil {
+		pString = source.Existing.Name
+	}
+	var pString2 *string
+	if pString != nil {
+		xstring := *pString
+		pString2 = &xstring
+	}
+	openapiInferenceService.Name = pString2
+	var pString3 *string
+	if source.Existing != nil {
+		pString3 = &source.Existing.RegisteredModelId
+	}
+	var xstring2 string
+	if pString3 != nil {
+		xstring2 = *pString3
+	}
+	openapiInferenceService.RegisteredModelId = xstring2
+	var pString4 *string
+	if source.Existing != nil {
+		pString4 = &source.Existing.ServingEnvironmentId
+	}
+	var xstring3 string
+	if pString4 != nil {
+		xstring3 = *pString4
+	}
+	openapiInferenceService.ServingEnvironmentId = xstring3
+	return openapiInferenceService, nil
+}
+func (c *OpenAPIConverterImpl) OverrideNotEditableForModelArtifact(source converter.OpenapiUpdateWrapper[openapi.ModelArtifact]) (openapi.ModelArtifact, error) {
+	openapiModelArtifact := converter.InitModelArtifactWithUpdate(source)
+	var pString *string
+	if source.Existing != nil {
+		pString = source.Existing.Name
+	}
+	var pString2 *string
+	if pString != nil {
+		xstring := *pString
+		pString2 = &xstring
+	}
+	openapiModelArtifact.Name = pString2
+	var pString3 *string
+	if source.Existing != nil {
+		pString3 = &source.Existing.ArtifactType
+	}
+	var xstring2 string
+	if pString3 != nil {
+		xstring2 = *pString3
+	}
+	openapiModelArtifact.ArtifactType = xstring2
+	return openapiModelArtifact, nil
+}
+func (c *OpenAPIConverterImpl) OverrideNotEditableForModelVersion(source converter.OpenapiUpdateWrapper[openapi.ModelVersion]) (openapi.ModelVersion, error) {
+	openapiModelVersion := converter.InitModelVersionWithUpdate(source)
+	var pString *string
+	if source.Existing != nil {
+		pString = source.Existing.Name
+	}
+	var pString2 *string
+	if pString != nil {
+		xstring := *pString
+		pString2 = &xstring
+	}
+	openapiModelVersion.Name = pString2
+	var pOpenapiModelVersionState *openapi.ModelVersionState
+	if source.Existing != nil {
+		pOpenapiModelVersionState = source.Existing.State
+	}
+	var pOpenapiModelVersionState2 *openapi.ModelVersionState
+	if pOpenapiModelVersionState != nil {
+		openapiModelVersionState := openapi.ModelVersionState(*pOpenapiModelVersionState)
+		pOpenapiModelVersionState2 = &openapiModelVersionState
+	}
+	openapiModelVersion.State = pOpenapiModelVersionState2
+	return openapiModelVersion, nil
+}
+func (c *OpenAPIConverterImpl) OverrideNotEditableForRegisteredModel(source converter.OpenapiUpdateWrapper[openapi.RegisteredModel]) (openapi.RegisteredModel, error) {
+	openapiRegisteredModel := converter.InitRegisteredModelWithUpdate(source)
+	var pString *string
+	if source.Existing != nil {
+		pString = source.Existing.Name
+	}
+	var pString2 *string
+	if pString != nil {
+		xstring := *pString
+		pString2 = &xstring
+	}
+	openapiRegisteredModel.Name = pString2
+	var pOpenapiRegisteredModelState *openapi.RegisteredModelState
+	if source.Existing != nil {
+		pOpenapiRegisteredModelState = source.Existing.State
+	}
+	var pOpenapiRegisteredModelState2 *openapi.RegisteredModelState
+	if pOpenapiRegisteredModelState != nil {
+		openapiRegisteredModelState := openapi.RegisteredModelState(*pOpenapiRegisteredModelState)
+		pOpenapiRegisteredModelState2 = &openapiRegisteredModelState
+	}
+	openapiRegisteredModel.State = pOpenapiRegisteredModelState2
+	return openapiRegisteredModel, nil
+}
+func (c *OpenAPIConverterImpl) OverrideNotEditableForServeModel(source converter.OpenapiUpdateWrapper[openapi.ServeModel]) (openapi.ServeModel, error) {
+	openapiServeModel := converter.InitServeModelWithUpdate(source)
+	var pString *string
+	if source.Existing != nil {
+		pString = source.Existing.Name
+	}
+	var pString2 *string
+	if pString != nil {
+		xstring := *pString
+		pString2 = &xstring
+	}
+	openapiServeModel.Name = pString2
+	var pString3 *string
+	if source.Existing != nil {
+		pString3 = &source.Existing.ModelVersionId
+	}
+	var xstring2 string
+	if pString3 != nil {
+		xstring2 = *pString3
+	}
+	openapiServeModel.ModelVersionId = xstring2
+	return openapiServeModel, nil
+}
+func (c *OpenAPIConverterImpl) OverrideNotEditableForServingEnvironment(source converter.OpenapiUpdateWrapper[openapi.ServingEnvironment]) (openapi.ServingEnvironment, error) {
+	openapiServingEnvironment := converter.InitServingEnvironmentWithUpdate(source)
+	var pString *string
+	if source.Existing != nil {
+		pString = source.Existing.Name
+	}
+	var pString2 *string
+	if pString != nil {
+		xstring := *pString
+		pString2 = &xstring
+	}
+	openapiServingEnvironment.Name = pString2
+	return openapiServingEnvironment, nil
 }
 func (c *OpenAPIConverterImpl) openapiMetadataValueToOpenapiMetadataValue(source openapi.MetadataValue) openapi.MetadataValue {
 	var openapiMetadataValue openapi.MetadataValue

--- a/internal/converter/opeanpi_converter.go
+++ b/internal/converter/opeanpi_converter.go
@@ -2,6 +2,32 @@ package converter
 
 import "github.com/opendatahub-io/model-registry/pkg/openapi"
 
+type OpenapiUpdateWrapper[
+	M openapi.RegisteredModel |
+		openapi.ModelVersion |
+		openapi.ModelArtifact |
+		openapi.ServingEnvironment |
+		openapi.InferenceService |
+		openapi.ServeModel,
+] struct {
+	Existing *M
+	Update   *M
+}
+
+func NewOpenapiUpdateWrapper[
+	M openapi.RegisteredModel |
+		openapi.ModelVersion |
+		openapi.ModelArtifact |
+		openapi.ServingEnvironment |
+		openapi.InferenceService |
+		openapi.ServeModel,
+](existing *M, update *M) OpenapiUpdateWrapper[M] {
+	return OpenapiUpdateWrapper[M]{
+		Existing: existing,
+		Update:   update,
+	}
+}
+
 // goverter:converter
 // goverter:output:file ./generated/openapi_converter.gen.go
 // goverter:wrapErrors
@@ -43,4 +69,82 @@ type OpenAPIConverter interface {
 
 	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Name ModelVersionId
 	ConvertServeModelUpdate(source *openapi.ServeModelUpdate) (*openapi.ServeModel, error)
+
+	// Ignore all fields that ARE editable
+	// goverter:default InitRegisteredModelWithUpdate
+	// goverter:autoMap Existing
+	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Description ExternalID CustomProperties
+	OverrideNotEditableForRegisteredModel(source OpenapiUpdateWrapper[openapi.RegisteredModel]) (openapi.RegisteredModel, error)
+
+	// Ignore all fields that ARE editable
+	// goverter:default InitModelVersionWithUpdate
+	// goverter:autoMap Existing
+	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Description ExternalID CustomProperties
+	OverrideNotEditableForModelVersion(source OpenapiUpdateWrapper[openapi.ModelVersion]) (openapi.ModelVersion, error)
+
+	// Ignore all fields that ARE editable
+	// goverter:default InitModelArtifactWithUpdate
+	// goverter:autoMap Existing
+	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Description ExternalID CustomProperties Uri State ServiceAccountName ModelFormatName ModelFormatVersion StorageKey StoragePath
+	OverrideNotEditableForModelArtifact(source OpenapiUpdateWrapper[openapi.ModelArtifact]) (openapi.ModelArtifact, error)
+
+	// Ignore all fields that ARE editable
+	// goverter:default InitServingEnvironmentWithUpdate
+	// goverter:autoMap Existing
+	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Description ExternalID CustomProperties
+	OverrideNotEditableForServingEnvironment(source OpenapiUpdateWrapper[openapi.ServingEnvironment]) (openapi.ServingEnvironment, error)
+
+	// Ignore all fields that ARE editable
+	// goverter:default InitInferenceServiceWithUpdate
+	// goverter:autoMap Existing
+	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Description ExternalID CustomProperties ModelVersionId Runtime State
+	OverrideNotEditableForInferenceService(source OpenapiUpdateWrapper[openapi.InferenceService]) (openapi.InferenceService, error)
+
+	// Ignore all fields that ARE editable
+	// goverter:default InitServeModelWithUpdate
+	// goverter:autoMap Existing
+	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Description ExternalID CustomProperties LastKnownState
+	OverrideNotEditableForServeModel(source OpenapiUpdateWrapper[openapi.ServeModel]) (openapi.ServeModel, error)
+}
+
+func InitRegisteredModelWithUpdate(source OpenapiUpdateWrapper[openapi.RegisteredModel]) openapi.RegisteredModel {
+	if source.Update != nil {
+		return *source.Update
+	}
+	return openapi.RegisteredModel{}
+}
+
+func InitModelVersionWithUpdate(source OpenapiUpdateWrapper[openapi.ModelVersion]) openapi.ModelVersion {
+	if source.Update != nil {
+		return *source.Update
+	}
+	return openapi.ModelVersion{}
+}
+
+func InitModelArtifactWithUpdate(source OpenapiUpdateWrapper[openapi.ModelArtifact]) openapi.ModelArtifact {
+	if source.Update != nil {
+		return *source.Update
+	}
+	return openapi.ModelArtifact{}
+}
+
+func InitServingEnvironmentWithUpdate(source OpenapiUpdateWrapper[openapi.ServingEnvironment]) openapi.ServingEnvironment {
+	if source.Update != nil {
+		return *source.Update
+	}
+	return openapi.ServingEnvironment{}
+}
+
+func InitInferenceServiceWithUpdate(source OpenapiUpdateWrapper[openapi.InferenceService]) openapi.InferenceService {
+	if source.Update != nil {
+		return *source.Update
+	}
+	return openapi.InferenceService{}
+}
+
+func InitServeModelWithUpdate(source OpenapiUpdateWrapper[openapi.ServeModel]) openapi.ServeModel {
+	if source.Update != nil {
+		return *source.Update
+	}
+	return openapi.ServeModel{}
 }

--- a/internal/converter/opeanpi_converter.go
+++ b/internal/converter/opeanpi_converter.go
@@ -2,31 +2,10 @@ package converter
 
 import "github.com/opendatahub-io/model-registry/pkg/openapi"
 
-type OpenapiUpdateWrapper[
-	M openapi.RegisteredModel |
-		openapi.ModelVersion |
-		openapi.ModelArtifact |
-		openapi.ServingEnvironment |
-		openapi.InferenceService |
-		openapi.ServeModel,
-] struct {
-	Existing *M
-	Update   *M
-}
-
-func NewOpenapiUpdateWrapper[
-	M openapi.RegisteredModel |
-		openapi.ModelVersion |
-		openapi.ModelArtifact |
-		openapi.ServingEnvironment |
-		openapi.InferenceService |
-		openapi.ServeModel,
-](existing *M, update *M) OpenapiUpdateWrapper[M] {
-	return OpenapiUpdateWrapper[M]{
-		Existing: existing,
-		Update:   update,
-	}
-}
+// NOTE: methods must follow these patterns, otherwise tests could not find possible issues:
+// Converters createEntity to entity: Convert<ENTITY>Create
+// Converters updateEntity to entity: Convert<ENTITY>Update
+// Converters override fields entity: OverrideNotEditableFor<ENTITY>
 
 // goverter:converter
 // goverter:output:file ./generated/openapi_converter.gen.go
@@ -73,13 +52,13 @@ type OpenAPIConverter interface {
 	// Ignore all fields that ARE editable
 	// goverter:default InitRegisteredModelWithUpdate
 	// goverter:autoMap Existing
-	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Description ExternalID CustomProperties
+	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Description ExternalID CustomProperties State
 	OverrideNotEditableForRegisteredModel(source OpenapiUpdateWrapper[openapi.RegisteredModel]) (openapi.RegisteredModel, error)
 
 	// Ignore all fields that ARE editable
 	// goverter:default InitModelVersionWithUpdate
 	// goverter:autoMap Existing
-	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Description ExternalID CustomProperties
+	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Description ExternalID CustomProperties State
 	OverrideNotEditableForModelVersion(source OpenapiUpdateWrapper[openapi.ModelVersion]) (openapi.ModelVersion, error)
 
 	// Ignore all fields that ARE editable
@@ -105,46 +84,4 @@ type OpenAPIConverter interface {
 	// goverter:autoMap Existing
 	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Description ExternalID CustomProperties LastKnownState
 	OverrideNotEditableForServeModel(source OpenapiUpdateWrapper[openapi.ServeModel]) (openapi.ServeModel, error)
-}
-
-func InitRegisteredModelWithUpdate(source OpenapiUpdateWrapper[openapi.RegisteredModel]) openapi.RegisteredModel {
-	if source.Update != nil {
-		return *source.Update
-	}
-	return openapi.RegisteredModel{}
-}
-
-func InitModelVersionWithUpdate(source OpenapiUpdateWrapper[openapi.ModelVersion]) openapi.ModelVersion {
-	if source.Update != nil {
-		return *source.Update
-	}
-	return openapi.ModelVersion{}
-}
-
-func InitModelArtifactWithUpdate(source OpenapiUpdateWrapper[openapi.ModelArtifact]) openapi.ModelArtifact {
-	if source.Update != nil {
-		return *source.Update
-	}
-	return openapi.ModelArtifact{}
-}
-
-func InitServingEnvironmentWithUpdate(source OpenapiUpdateWrapper[openapi.ServingEnvironment]) openapi.ServingEnvironment {
-	if source.Update != nil {
-		return *source.Update
-	}
-	return openapi.ServingEnvironment{}
-}
-
-func InitInferenceServiceWithUpdate(source OpenapiUpdateWrapper[openapi.InferenceService]) openapi.InferenceService {
-	if source.Update != nil {
-		return *source.Update
-	}
-	return openapi.InferenceService{}
-}
-
-func InitServeModelWithUpdate(source OpenapiUpdateWrapper[openapi.ServeModel]) openapi.ServeModel {
-	if source.Update != nil {
-		return *source.Update
-	}
-	return openapi.ServeModel{}
 }

--- a/internal/converter/openapi_converter_test.go
+++ b/internal/converter/openapi_converter_test.go
@@ -1,0 +1,160 @@
+package converter
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/opendatahub-io/model-registry/pkg/openapi"
+)
+
+// visitor
+type visitor struct {
+	t        *testing.T
+	entities map[string]*oapiEntity
+}
+
+func newVisitor(t *testing.T, f *ast.File) visitor {
+	return visitor{
+		t: t,
+		entities: map[string]*oapiEntity{
+			"RegisteredModel": {
+				obj: openapi.RegisteredModel{},
+			},
+			"ModelVersion": {
+				obj: openapi.ModelVersion{},
+			},
+			"ModelArtifact": {
+				obj: openapi.ModelArtifact{},
+			},
+			"ServingEnvironment": {
+				obj: openapi.ServingEnvironment{},
+			},
+			"InferenceService": {
+				obj: openapi.InferenceService{},
+			},
+			"ServeModel": {
+				obj: openapi.ServeModel{},
+			},
+		},
+	}
+}
+
+func (v *visitor) extractGroup(regex *regexp.Regexp, s string) string {
+	extracted := regex.FindStringSubmatch(s)
+	if len(extracted) != 2 {
+		v.t.Errorf("unable to extract groups from %s for %s", regex.String(), s)
+	}
+	// the first one is the wole matched string, the second one is the group
+	return extracted[1]
+}
+
+func (v *visitor) getEntity(name string) *oapiEntity {
+	val, ok := v.entities[name]
+	if !ok {
+		v.t.Errorf("openapi entity not found in the entities map: %s", name)
+	}
+	return val
+}
+
+func (v visitor) Visit(n ast.Node) ast.Visitor {
+	if n == nil {
+		return nil
+	}
+
+	switch d := n.(type) {
+	case *ast.InterfaceType:
+		for _, m := range d.Methods.List {
+			methodName := m.Names[0].Name
+
+			if converterMethodPattern.MatchString(methodName) {
+				entityName := v.extractGroup(converterMethodPattern, methodName)
+				entity := v.getEntity(entityName)
+				// there should be just one doc comment matching ignoreDirectivePattern
+				for _, c := range m.Doc.List {
+					if ignoreDirectivePattern.MatchString(c.Text) {
+						entity.notEditableFields = v.extractGroup(ignoreDirectivePattern, c.Text)
+					}
+				}
+			} else if overrideNotEditableMethodPattern.MatchString(methodName) {
+				entityName := v.extractGroup(overrideNotEditableMethodPattern, methodName)
+				entity := v.getEntity(entityName)
+				// there should be just one doc comment matching ignoreDirectivePattern
+				for _, c := range m.Doc.List {
+					if ignoreDirectivePattern.MatchString(c.Text) {
+						entity.ignoredFields = v.extractGroup(ignoreDirectivePattern, c.Text)
+					}
+				}
+			}
+		}
+		v.checkEntities()
+	}
+	return v
+}
+
+// checkEntities check if all editable fields are listed in the goverter ignore directive of OverrideNotEditableFor
+func (v *visitor) checkEntities() {
+	errorMsgs := map[string][]string{}
+	for k, v := range v.entities {
+		msgs := checkEntity(v)
+		if len(msgs) > 0 {
+			errorMsgs[k] = msgs
+		}
+	}
+
+	if len(errorMsgs) > 0 {
+		missingFieldsMsg := ""
+		for k, fields := range errorMsgs {
+			missingFieldsMsg += fmt.Sprintf("%s: %v\n", k, fields)
+		}
+		v.t.Errorf("missing fields to be ignored for OverrideNotEditableFor* goverter methods:\n%v", missingFieldsMsg)
+	}
+}
+
+// checkEntity check if there are missing fields to be ignored in the override method
+func checkEntity(entity *oapiEntity) []string {
+	res := []string{}
+	objType := reflect.TypeOf(entity.obj)
+	for i := 0; i < objType.NumField(); i++ {
+		field := objType.Field(i)
+		if !strings.Contains(entity.notEditableFields, field.Name) && !strings.Contains(entity.ignoredFields, field.Name) {
+			// check if the not editable field (first check) is not present in the ignored fields (second check)
+			// if this condition is true, we missed that field in the Override method ignore list
+			res = append(res, field.Name)
+		}
+	}
+	return res
+}
+
+// test
+
+var converterMethodPattern *regexp.Regexp = regexp.MustCompile(`Convert(?P<entity>\w+)Update`)
+var overrideNotEditableMethodPattern *regexp.Regexp = regexp.MustCompile(`OverrideNotEditableFor(?P<entity>\w+)`)
+var ignoreDirectivePattern *regexp.Regexp = regexp.MustCompile(`// goverter:ignore (?P<fields>.+)`)
+
+func TestOverrideNotEditableFields(t *testing.T) {
+	_ = setup(t)
+
+	fset := token.NewFileSet() // positions are relative to fset
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Errorf("error getting current working directory")
+	}
+	filePath := fmt.Sprintf("%s/opeanpi_converter.go", wd)
+	f, _ := parser.ParseFile(fset, filePath, nil, parser.ParseComments)
+
+	v := newVisitor(t, f)
+	ast.Walk(v, f)
+}
+
+type oapiEntity struct {
+	obj               any
+	notEditableFields string
+	ignoredFields     string
+}

--- a/internal/converter/openapi_converter_util.go
+++ b/internal/converter/openapi_converter_util.go
@@ -1,0 +1,71 @@
+package converter
+
+import "github.com/opendatahub-io/model-registry/pkg/openapi"
+
+type OpenapiUpdateWrapper[
+	M openapi.RegisteredModel |
+		openapi.ModelVersion |
+		openapi.ModelArtifact |
+		openapi.ServingEnvironment |
+		openapi.InferenceService |
+		openapi.ServeModel,
+] struct {
+	Existing *M
+	Update   *M
+}
+
+func NewOpenapiUpdateWrapper[
+	M openapi.RegisteredModel |
+		openapi.ModelVersion |
+		openapi.ModelArtifact |
+		openapi.ServingEnvironment |
+		openapi.InferenceService |
+		openapi.ServeModel,
+](existing *M, update *M) OpenapiUpdateWrapper[M] {
+	return OpenapiUpdateWrapper[M]{
+		Existing: existing,
+		Update:   update,
+	}
+}
+
+func InitRegisteredModelWithUpdate(source OpenapiUpdateWrapper[openapi.RegisteredModel]) openapi.RegisteredModel {
+	if source.Update != nil {
+		return *source.Update
+	}
+	return openapi.RegisteredModel{}
+}
+
+func InitModelVersionWithUpdate(source OpenapiUpdateWrapper[openapi.ModelVersion]) openapi.ModelVersion {
+	if source.Update != nil {
+		return *source.Update
+	}
+	return openapi.ModelVersion{}
+}
+
+func InitModelArtifactWithUpdate(source OpenapiUpdateWrapper[openapi.ModelArtifact]) openapi.ModelArtifact {
+	if source.Update != nil {
+		return *source.Update
+	}
+	return openapi.ModelArtifact{}
+}
+
+func InitServingEnvironmentWithUpdate(source OpenapiUpdateWrapper[openapi.ServingEnvironment]) openapi.ServingEnvironment {
+	if source.Update != nil {
+		return *source.Update
+	}
+	return openapi.ServingEnvironment{}
+}
+
+func InitInferenceServiceWithUpdate(source OpenapiUpdateWrapper[openapi.InferenceService]) openapi.InferenceService {
+	if source.Update != nil {
+		return *source.Update
+	}
+	return openapi.InferenceService{}
+}
+
+func InitServeModelWithUpdate(source OpenapiUpdateWrapper[openapi.ServeModel]) openapi.ServeModel {
+	if source.Update != nil {
+		return *source.Update
+	}
+	return openapi.ServeModel{}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/opendatahub-io/model-registry/issues/199

## Description
<!--- Describe your changes in detail -->
As per related issue description, this PR aims to fix the update issue for `InferenceService` and `ServeModel`.
Created `OverrideNotEditableFor<Entity>` converters that take `<existing, update>` and override the NOT editable fields in the `update` object by taking those values from the `existing`.

With this approach I was able to remove the `Name` override in the core functions.

**NOTE**: everytime we add a new field in the openapi spec that can be editable, we should `ignore` it in the `OverrideNotEditableFor<Entity>` converters.

> Since I have updated the `goverter` version, I recommend to run `make clean/deps` and then `make build`  to download te proper version of goverter.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
make test
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->


- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
