### PR TITLE
Python client: Fix docs

### DIFF
--- a/clients/python/src/model_registry/client.py
+++ b/clients/python/src/model_registry/client.py
@@ -26,11 +26,11 @@ class ModelRegistry:
         """Constructor.
 
         Args:
-            server_address (str): Server address.
-            port (int): Server port.
-            client_key (str, optional): The PEM-encoded private key as a byte string.
-            server_cert (str, optional): The PEM-encoded certificate as a byte string.
-            custom_ca (str, optional): The PEM-encoded root certificates as a byte string.
+            server_address: Server address.
+            port: Server port.
+            client_key: The PEM-encoded private key as a byte string.
+            server_cert: The PEM-encoded certificate as a byte string.
+            custom_ca: The PEM-encoded root certificates as a byte string.
         """
         config = MetadataStoreClientConfig()
         config.host = server_address
@@ -49,10 +49,10 @@ class ModelRegistry:
         Helper around the `map` method of the Python object.
 
         Args:
-            py_obj (Mappable): Python object.
+            py_obj: Python object.
 
         Returns:
-            ProtoType: Proto object.
+            Proto object.
         """
         type_id = self._store.get_type_id(
             py_obj.get_proto_type(), py_obj.get_proto_type_name()
@@ -66,10 +66,10 @@ class ModelRegistry:
         This updates the registered_model instance passed in with new data from the servers.
 
         Args:
-            registered_model (RegisteredModel): Registered model.
+            registered_model: Registered model.
 
         Returns:
-            str: ID of the registered model.
+            ID of the registered model.
         """
         id = self._store.put_context(self._map(registered_model))
         new_py_rm = RegisteredModel.unmap(
@@ -87,10 +87,10 @@ class ModelRegistry:
         """Fetch a registered model by its ID.
 
         Args:
-            id (str): Registered model ID.
+            id: Registered model ID.
 
         Returns:
-            RegisteredModel: Registered model.
+            Registered model.
         """
         py_rm = RegisteredModel.unmap(
             self._store.get_context(RegisteredModel.get_proto_type_name(), id=int(id))
@@ -106,11 +106,11 @@ class ModelRegistry:
         """Fetch a registered model by its name or external ID.
 
         Args:
-            name (str, optional): Registered model name.
-            external_id (str, optional): Registered model external ID.
+            name: Registered model name.
+            external_id: Registered model external ID.
 
         Returns:
-            RegisteredModel: Registered model.
+            Registered model.
         """
         if name is None and external_id is None:
             msg = "Either name or external_id must be provided"
@@ -134,10 +134,10 @@ class ModelRegistry:
         """Fetch registered models.
 
         Args:
-            options (ListOptions, optional): Options for listing registered models.
+            options: Options for listing registered models.
 
         Returns:
-            Sequence[RegisteredModel]: Registered models.
+            Registered models.
         """
         mlmd_options = options.as_mlmd_list_options() if options else MLMDListOptions()
         proto_rms = self._store.get_contexts(
@@ -154,11 +154,11 @@ class ModelRegistry:
         This updates the model_version instance passed in with new data from the servers.
 
         Args:
-            model_version (ModelVersion): Model version to upsert.
-            registered_model_id (str): ID of the registered model this version will be associated to.
+            model_version: Model version to upsert.
+            registered_model_id: ID of the registered model this version will be associated to.
 
         Returns:
-            str: ID of the model version.
+            ID of the model version.
         """
         rm_id = int(registered_model_id)
         # this is not ideal but we need this info for the prefix
@@ -180,10 +180,10 @@ class ModelRegistry:
         """Fetch a model version by its ID.
 
         Args:
-            model_version_id (str): Model version ID.
+            model_version_id: Model version ID.
 
         Returns:
-            ModelVersion: Model version.
+            Model version.
         """
         py_mv = ModelVersion.unmap(
             self._store.get_context(
@@ -201,11 +201,11 @@ class ModelRegistry:
         """Fetch model versions by registered model ID.
 
         Args:
-            registered_model_id (str): Registered model ID.
-            options (ListOptions, optional): Options for listing model versions.
+            registered_model_id: Registered model ID.
+            options: Options for listing model versions.
 
         Returns:
-            Sequence[ModelVersion]: Model versions.
+            Model versions.
         """
         mlmd_options = options.as_mlmd_list_options() if options else MLMDListOptions()
         mlmd_options.filter_query = f"parent_contexts_a.id = {registered_model_id}"
@@ -231,12 +231,12 @@ class ModelRegistry:
         Either fetches by using external ID or by using registered model ID and version.
 
         Args:
-            registered_model_id (str, optional): Registered model ID.
-            version (str, optional): Model version.
-            external_id (str, optional): Model version external ID.
+            registered_model_id: Registered model ID.
+            version: Model version.
+            external_id: Model version external ID.
 
         Returns:
-            ModelVersion: Model version.
+            Model version.
         """
         if external_id is not None:
             proto_mv = self._store.get_context(
@@ -265,11 +265,11 @@ class ModelRegistry:
         This updates the model_artifact instance passed in with new data from the servers.
 
         Args:
-            model_artifact (ModelArtifact): Model artifact to upsert.
-            model_version_id (str): ID of the model version this artifact will be associated to.
+            model_artifact: Model artifact to upsert.
+            model_version_id: ID of the model version this artifact will be associated to.
 
         Returns:
-            str: ID of the model artifact.
+            ID of the model artifact.
         """
         mv_id = int(model_version_id)
         try:
@@ -299,10 +299,10 @@ class ModelRegistry:
         """Fetch a model artifact by its ID.
 
         Args:
-            id (str): Model artifact ID.
+            id: Model artifact ID.
 
         Returns:
-            ModelArtifact: Model artifact.
+            Model artifact.
         """
         proto_ma = self._store.get_artifact(
             ModelArtifact.get_proto_type_name(), int(id)
@@ -315,11 +315,11 @@ class ModelRegistry:
         """Fetch a model artifact either by external ID or by the ID of its associated model version.
 
         Args:
-            model_version_id (str, optional): ID of the associated model version.
-            external_id (str, optional): Model artifact external ID.
+            model_version_id: ID of the associated model version.
+            external_id: Model artifact external ID.
 
         Returns:
-            ModelArtifact: Model artifact.
+            Model artifact.
         """
         if external_id:
             proto_ma = self._store.get_artifact(
@@ -342,11 +342,11 @@ class ModelRegistry:
         """Fetches model artifacts.
 
         Args:
-            model_version_id (str, optional): ID of the associated model version.
-            options (ListOptions, optional): Options for listing model artifacts.
+            model_version_id: ID of the associated model version.
+            options: Options for listing model artifacts.
 
         Returns:
-            Sequence[ModelArtifact]: Model artifacts.
+            Model artifacts.
         """
         mlmd_options = options.as_mlmd_list_options() if options else MLMDListOptions()
         if model_version_id is not None:

--- a/clients/python/src/model_registry/store/wrapper.py
+++ b/clients/python/src/model_registry/store/wrapper.py
@@ -36,7 +36,7 @@ class MLMDStore:
         """Constructor.
 
         Args:
-            config (MetadataStoreClientConfig): MLMD config.
+            config: MLMD config.
         """
         self._mlmd_store = MetadataStore(config)
 
@@ -44,11 +44,11 @@ class MLMDStore:
         """Get backend ID for a type.
 
         Args:
-            mlmd_pt (ProtoType): Proto type.
-            type_name (str): Name of the type.
+            mlmd_pt: Proto type.
+            type_name: Name of the type.
 
         Returns:
-            int: Backend ID.
+            Backend ID.
 
         Raises:
             TypeNotFoundException: If the type doesn't exist.
@@ -85,10 +85,10 @@ class MLMDStore:
         """Put an artifact in the store.
 
         Args:
-            artifact (Artifact): Artifact to put.
+            artifact: Artifact to put.
 
         Returns:
-            int: ID of the artifact.
+            ID of the artifact.
 
         Raises:
             DuplicateException: If an artifact with the same name or external id already exists.
@@ -111,10 +111,10 @@ class MLMDStore:
         """Put a context in the store.
 
         Args:
-            context (Context): Context to put.
+            context: Context to put.
 
         Returns:
-            int: ID of the context.
+            ID of the context.
 
         Raises:
             DuplicateException: If a context with the same name or external id already exists.
@@ -151,13 +151,13 @@ class MLMDStore:
         If multiple arguments are provided, the simplest query will be performed.
 
         Args:
-            ctx_type_name (str): Name of the context type.
-            id (int, optional): ID of the context.
-            name (str, optional): Name of the context.
-            external_id (str, optional): External ID of the context.
+            ctx_type_name: Name of the context type.
+            id: ID of the context.
+            name: Name of the context.
+            external_id: External ID of the context.
 
         Returns:
-            Context: Context.
+            Context.
 
         Raises:
             StoreException: If the context doesn't exist.
@@ -186,11 +186,11 @@ class MLMDStore:
         """Get contexts from the store.
 
         Args:
-            ctx_type_name (str): Name of the context type.
-            options (ListOptions): List options.
+            ctx_type_name: Name of the context type.
+            options: List options.
 
         Returns:
-            Sequence[Context]: Contexts.
+            Contexts.
         """
         # TODO: should we make options optional?
         # if options is not None:
@@ -217,8 +217,8 @@ class MLMDStore:
         """Put a parent-child relationship between two contexts.
 
         Args:
-            parent_id (int): ID of the parent context.
-            child_id (int): ID of the child context.
+            parent_id: ID of the parent context.
+            child_id: ID of the child context.
 
         Raises:
             StoreException: If the parent context doesn't exist.
@@ -239,8 +239,8 @@ class MLMDStore:
         """Put an attribution relationship between a context and an artifact.
 
         Args:
-            context_id (int): ID of the context.
-            artifact_id (int): ID of the artifact.
+            context_id: ID of the context.
+            artifact_id: ID of the artifact.
 
         Raises:
             StoreException: Invalid argument.
@@ -272,13 +272,13 @@ class MLMDStore:
         Gets an artifact either by ID, name or external ID.
 
         Args:
-            art_type_name (str): Name of the artifact type.
-            id (int, optional): ID of the artifact.
-            name (str, optional): Name of the artifact.
-            external_id (str, optional): External ID of the artifact.
+            art_type_name: Name of the artifact type.
+            id: ID of the artifact.
+            name: Name of the artifact.
+            external_id: External ID of the artifact.
 
         Returns:
-            Artifact: Artifact.
+            Artifact.
 
         Raises:
             StoreException: If the context doesn't exist.
@@ -305,11 +305,11 @@ class MLMDStore:
         """Get an artifact from the store by its attributed context.
 
         Args:
-            art_type_name (str): Name of the artifact type.
-            ctx_id (int): ID of the context.
+            art_type_name: Name of the artifact type.
+            ctx_id: ID of the context.
 
         Returns:
-            Artifact: Artifact.
+            Artifact.
         """
         try:
             artifacts = self._mlmd_store.get_artifacts_by_context(ctx_id)
@@ -328,11 +328,11 @@ class MLMDStore:
         """Get artifacts from the store.
 
         Args:
-            art_type_name (str): Name of the artifact type.
-            options (ListOptions): List options.
+            art_type_name: Name of the artifact type.
+            options: List options.
 
         Returns:
-            Sequence[Artifact]: Artifacts.
+            Artifacts.
         """
         try:
             artifacts = self._mlmd_store.get_artifacts(options)

--- a/clients/python/src/model_registry/types/artifacts.py
+++ b/clients/python/src/model_registry/types/artifacts.py
@@ -84,9 +84,9 @@ class ModelArtifact(BaseArtifact, Prefixable):
         external_id (str, optional): Customizable ID. Has to be unique among instances of the same type.
         model_format_name (str, optional): Name of the model format.
         model_format_version (str, optional): Version of the model format.
-        storage_key (str, optional): Storage key of the model.
+        storage_key (str, optional): Storage secret name.
         storage_path (str, optional): Storage path of the model.
-        service_account_name (str, optional): Service account name of the model.
+        service_account_name (str, optional): Name of the service account with storage secret.
     """
 
     # TODO: this could be an enum of valid formats

--- a/clients/python/src/model_registry/types/artifacts.py
+++ b/clients/python/src/model_registry/types/artifacts.py
@@ -40,9 +40,9 @@ class BaseArtifact(ProtoBase):
     """Abstract base class for all artifacts.
 
     Attributes:
-        name (str): Name of the artifact.
-        uri (str): URI of the artifact.
-        state (ArtifactState): State of the artifact.
+        name: Name of the artifact.
+        uri: URI of the artifact.
+        state: State of the artifact.
     """
 
     name: str
@@ -78,15 +78,15 @@ class ModelArtifact(BaseArtifact, Prefixable):
     """Represents a Model.
 
     Attributes:
-        name (str): Name of the model.
-        uri (str): URI of the model.
-        description (str, optional): Description of the object.
-        external_id (str, optional): Customizable ID. Has to be unique among instances of the same type.
-        model_format_name (str, optional): Name of the model format.
-        model_format_version (str, optional): Version of the model format.
-        storage_key (str, optional): Storage secret name.
-        storage_path (str, optional): Storage path of the model.
-        service_account_name (str, optional): Name of the service account with storage secret.
+        name: Name of the model.
+        uri: URI of the model.
+        description: Description of the object.
+        external_id: Customizable ID. Has to be unique among instances of the same type.
+        model_format_name: Name of the model format.
+        model_format_version: Version of the model format.
+        storage_key: Storage secret name.
+        storage_path: Storage path of the model.
+        service_account_name: Name of the service account with storage secret.
     """
 
     # TODO: this could be an enum of valid formats

--- a/clients/python/src/model_registry/types/base.py
+++ b/clients/python/src/model_registry/types/base.py
@@ -20,7 +20,7 @@ class Mappable(ABC):
         """Name of the proto type.
 
         Returns:
-            str: Name of the class prefixed with `odh.`
+            Name of the class prefixed with `odh.`
         """
         return f"odh.{cls.__name__}"
 
@@ -38,7 +38,7 @@ class Mappable(ABC):
             type_id (int): ID of the type.
 
         Returns:
-            ProtoType: Proto object.
+            Proto object.
         """
         pass
 
@@ -48,10 +48,10 @@ class Mappable(ABC):
         """Map from a proto object.
 
         Args:
-            mlmd_obj (ProtoType): Proto object.
+            mlmd_obj: Proto object.
 
         Returns:
-            Mappable: Python object.
+            Python object.
         """
         pass
 
@@ -78,12 +78,12 @@ class ProtoBase(Mappable, ABC):
     such as Artifacts, Contexts, and Executions.
 
     Attributes:
-        id (str): Protobuf object ID. Auto-assigned when put on the server.
-        name (str): Name of the object.
-        description (str, optional): Description of the object.
-        external_id (str, optional): Customizable ID. Has to be unique among instances of the same type.
-        create_time_since_epoch (int): Seconds elapsed since object creation time, measured against epoch.
-        last_update_time_since_epoch (int): Seconds elapsed since object last update time, measured against epoch.
+        id: Protobuf object ID. Auto-assigned when put on the server.
+        name: Name of the object.
+        description: Description of the object.
+        external_id: Customizable ID. Has to be unique among instances of the same type.
+        create_time_since_epoch: Seconds elapsed since object creation time, measured against epoch.
+        last_update_time_since_epoch: Seconds elapsed since object last update time, measured against epoch.
     """
 
     name: str = field(init=False)
@@ -106,7 +106,7 @@ class ProtoBase(Mappable, ABC):
         """Proto type associated with this class.
 
         Returns:
-            ProtoType: Proto type.
+            Proto type.
         """
         pass
 
@@ -117,8 +117,8 @@ class ProtoBase(Mappable, ABC):
         """Map properties from Python to proto.
 
         Args:
-            py_props (dict[str, ScalarType]): Python properties.
-            mlmd_props (dict[str, Any]): Proto properties, will be modified in place.
+            py_props: Python properties.
+            mlmd_props: Proto properties, will be modified in place.
         """
         for key, value in py_props.items():
             if value is None:
@@ -154,10 +154,10 @@ class ProtoBase(Mappable, ABC):
         """Map properties from proto to Python.
 
         Args:
-            mlmd_props (dict[str, Any]): Proto properties.
+            mlmd_props: Proto properties.
 
         Returns:
-            dict[str, ScalarType]: Python properties.
+            Python properties.
         """
         py_props: dict[str, ScalarType] = {}
         for key, value in mlmd_props.items():

--- a/clients/python/src/model_registry/types/contexts.py
+++ b/clients/python/src/model_registry/types/contexts.py
@@ -38,14 +38,14 @@ class ModelVersion(BaseContext, Prefixable):
     """Represents a model version.
 
     Attributes:
-        model (ModelArtifact): Model associated with this version.
-        version (str): Version of the model.
-        author (str): Author of the model version.
-        description (str, optional): Description of the object.
-        external_id (str, optional): Customizable ID. Has to be unique among instances of the same type.
-        artifacts (list[BaseArtifact]): Artifacts associated with this version.
-        tags (list[str]): Tags associated with this version.
-        metadata (dict[str, ScalarType]): Metadata associated with this version.
+        model: Model associated with this version.
+        version: Version of the model.
+        author: Author of the model version.
+        description: Description of the object.
+        external_id: Customizable ID. Has to be unique among instances of the same type.
+        artifacts: Artifacts associated with this version.
+        tags: Tags associated with this version.
+        metadata: Metadata associated with this version.
     """
 
     model: ModelArtifact
@@ -101,10 +101,10 @@ class RegisteredModel(BaseContext):
     """Represents a registered model.
 
     Attributes:
-        name (str): Registered model name.
-        description (str, optional): Description of the object.
-        external_id (str, optional): Customizable ID. Has to be unique among instances of the same type.
-        versions (list[ModelVersion]): Versions associated with this model.
+        name: Registered model name.
+        description: Description of the object.
+        external_id: Customizable ID. Has to be unique among instances of the same type.
+        versions: Versions associated with this model.
     """
 
     name: str

--- a/clients/python/src/model_registry/types/options.py
+++ b/clients/python/src/model_registry/types/options.py
@@ -25,9 +25,9 @@ class ListOptions:
     """Options for listing objects.
 
     Attributes:
-        limit (int): Maximum number of objects to return.
-        order_by (OrderByField, optional): Field to order by.
-        is_asc (bool): Whether to order in ascending order. Defaults to True.
+        limit: Maximum number of objects to return.
+        order_by: Field to order by.
+        is_asc: Whether to order in ascending order. Defaults to True.
     """
 
     limit: int | None = field(default=None)
@@ -38,7 +38,7 @@ class ListOptions:
         """Convert to MLMD ListOptions.
 
         Returns:
-            ListOptions: MLMD ListOptions.
+            MLMD ListOptions.
         """
         return MLMDListOptions(
             limit=self.limit,


### PR DESCRIPTION
Fixes docstrings related to storage attributes on Model Artifact. This also removes duplicate type annotations from docstrings, as they're not needed.

Depends on: #181 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
