### PR TITLE
Align MLMD Properties for Artifact

### DIFF
--- a/clients/python/src/model_registry/types/artifacts.py
+++ b/clients/python/src/model_registry/types/artifacts.py
@@ -107,11 +107,11 @@ class ModelArtifact(BaseArtifact, Prefixable):
     def map(self, type_id: int) -> Artifact:
         mlmd_obj = super().map(type_id)
         props = {
-            "modelFormatName": self.model_format_name,
-            "modelFormatVersion": self.model_format_version,
-            "storageKey": self.storage_key,
-            "storagePath": self.storage_path,
-            "serviceAccountName": self.service_account_name,
+            "model_format_name": self.model_format_name,
+            "model_format_version": self.model_format_version,
+            "storage_key": self.storage_key,
+            "storage_path": self.storage_path,
+            "service_account_name": self.service_account_name,
         }
         self._map_props(props, mlmd_obj.properties)
         return mlmd_obj
@@ -123,13 +123,13 @@ class ModelArtifact(BaseArtifact, Prefixable):
         assert isinstance(
             py_obj, ModelArtifact
         ), f"Expected ModelArtifact, got {type(py_obj)}"
-        py_obj.model_format_name = mlmd_obj.properties["modelFormatName"].string_value
+        py_obj.model_format_name = mlmd_obj.properties["model_format_name"].string_value
         py_obj.model_format_version = mlmd_obj.properties[
-            "modelFormatVersion"
+            "model_format_version"
         ].string_value
-        py_obj.storage_key = mlmd_obj.properties["storageKey"].string_value
-        py_obj.storage_path = mlmd_obj.properties["storagePath"].string_value
+        py_obj.storage_key = mlmd_obj.properties["storage_key"].string_value
+        py_obj.storage_path = mlmd_obj.properties["storage_path"].string_value
         py_obj.service_account_name = mlmd_obj.properties[
-            "serviceAccountName"
+            "service_account_name"
         ].string_value
         return py_obj

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -32,11 +32,11 @@ def model(store_wrapper: MLMDStore) -> Mapped:
     art_type.name = ModelArtifact.get_proto_type_name()
     props = [
         "description",
-        "modelFormatName",
-        "modelFormatVersion",
-        "storageKey",
-        "storagePath",
-        "serviceAccountName",
+        "model_format_name",
+        "model_format_version",
+        "storage_key",
+        "storage_path",
+        "service_account_name",
     ]
     for key in props:
         art_type.properties[key] = metadata_store_pb2.STRING

--- a/clients/python/tests/types/test_artifact_mapping.py
+++ b/clients/python/tests/types/test_artifact_mapping.py
@@ -20,11 +20,11 @@ def complete_model() -> Mapped:
     proto_model.state = Artifact.UNKNOWN
     proto_model.uri = "test_uri"
     proto_model.properties["description"].string_value = "test description"
-    proto_model.properties["modelFormatName"].string_value = "test_format"
-    proto_model.properties["modelFormatVersion"].string_value = "test_format_version"
-    proto_model.properties["storageKey"].string_value = "test_storage_key"
-    proto_model.properties["storagePath"].string_value = "test_storage_path"
-    proto_model.properties["serviceAccountName"].string_value = "test_account_name"
+    proto_model.properties["model_format_name"].string_value = "test_format"
+    proto_model.properties["model_format_version"].string_value = "test_format_version"
+    proto_model.properties["storage_key"].string_value = "test_storage_key"
+    proto_model.properties["storage_path"].string_value = "test_storage_path"
+    proto_model.properties["service_account_name"].string_value = "test_account_name"
 
     py_model = ModelArtifact(
         "test_model",


### PR DESCRIPTION
Resolves #204

## Description
Not consistent with:

https://github.com/opendatahub-io/model-registry/blob/b4eebd6c073b1b047c94de198157cae2549d4bfd/pkg/core/core.go#L73-L77

Causing MR python client failures as described in #204 

## How Has This Been Tested?
`poetry run pytest`

and in Notebook:

```python
from model_registry import ModelRegistry
from model_registry.types import ModelArtifact, ModelVersion, RegisteredModel
from datetime import datetime

bucket_name = 'mybucket'
registeredmodel_name = "mnist-matteo"
version_name = "v"+datetime.now().strftime("%Y%m%d%H%M%S")

mr = ModelRegistry('modelregistry-sample', 9090)
try:
    rm_id = mr.get_registered_model_by_params(name=registeredmodel_name).id
except Exception as e:
    rm_id = mr.upsert_registered_model(RegisteredModel(registeredmodel_name))
mv_id = mr.upsert_model_version(ModelVersion(ModelArtifact('',''), version_name, "Data Scientist"), rm_id)
ma_id = mr.upsert_model_artifact(ModelArtifact(
    name='mnist',
    uri='s3://mybucket/experiment1',
    storage_key=f'aws-connection-{bucket_name}',
    storage_path='experiment1')
    , mv_id)
print(rm_id)
ma = mr.get_model_artifact_by_id(ma_id)
print(ma)
```

![image](https://github.com/opendatahub-io/model-registry/assets/1699252/362f82bd-061a-4a09-a4d0-efe15b323953)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
