### PR TITLE
Fix python client MR type definitions

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -70,9 +70,6 @@ another_model = registry.get_registered_model_by_id("another-model-id")
 
 another_version = registry.get_model_version_by_id("another-version-id", another_model.id)
 
-# fetching a version will also fetch its associated model artifact
-model_artifact = another_version.model
-
 another_trained_model = registry.get_model_artifact_by_id("another-model-artifact-id")
 ```
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -68,9 +68,6 @@ To query objects using IDs, do
 ```py
 another_model = registry.get_registered_model_by_id("another-model-id")
 
-# fetching a registered_model will also fetch its associated versions
-versions = another_model.versions
-
 another_version = registry.get_model_version_by_id("another-version-id", another_model.id)
 
 # fetching a version will also fetch its associated model artifact
@@ -134,10 +131,7 @@ models = registry.get_registered_models()
 
 versions = registry.get_model_versions("registered_model_id")
 
-# We can get associated model artifacts with the versions
-model_artifacts = [version.model for version in versions]
-
-# We can also get a list of all model artifacts
+# We can get a list of all model artifacts
 all_model_artifacts = registry.get_model_artifacts()
 ```
 

--- a/clients/python/src/model_registry/client.py
+++ b/clients/python/src/model_registry/client.py
@@ -185,19 +185,15 @@ class ModelRegistry:
         Returns:
             Model version.
         """
-        py_mv = ModelVersion.unmap(
+        return ModelVersion.unmap(
             self._store.get_context(
                 ModelVersion.get_proto_type_name(), id=int(model_version_id)
             )
         )
-        py_mv.model = self.get_model_artifact_by_params(
-            model_version_id=model_version_id
-        )
-        return py_mv
 
     def get_model_versions(
         self, registered_model_id: str, options: ListOptions | None = None
-    ) -> Sequence[ModelVersion]:
+    ) -> list[ModelVersion]:
         """Fetch model versions by registered model ID.
 
         Args:
@@ -209,16 +205,12 @@ class ModelRegistry:
         """
         mlmd_options = options.as_mlmd_list_options() if options else MLMDListOptions()
         mlmd_options.filter_query = f"parent_contexts_a.id = {registered_model_id}"
-        proto_mvs = self._store.get_contexts(
-            ModelVersion.get_proto_type_name(), mlmd_options
-        )
-        py_mvs: list[ModelVersion] = []
-        for proto_mv in proto_mvs:
-            py_mv = ModelVersion.unmap(proto_mv)
-            assert py_mv.id is not None, "Model version ID is None"
-            py_mv.model = self.get_model_artifact_by_params(model_version_id=py_mv.id)
-            py_mvs.append(py_mv)
-        return py_mvs
+        return [
+            ModelVersion.unmap(proto_mv)
+            for proto_mv in self._store.get_contexts(
+                ModelVersion.get_proto_type_name(), mlmd_options
+            )
+        ]
 
     def get_model_version_by_params(
         self,
@@ -252,9 +244,7 @@ class ModelRegistry:
                 ModelVersion.get_proto_type_name(),
                 name=f"{registered_model_id}:{version}",
             )
-        py_mv = ModelVersion.unmap(proto_mv)
-        py_mv.model = self.get_model_artifact_by_params(model_version_id=py_mv.id)
-        return py_mv
+        return ModelVersion.unmap(proto_mv)
 
     def upsert_model_artifact(
         self, model_artifact: ModelArtifact, model_version_id: str

--- a/clients/python/src/model_registry/client.py
+++ b/clients/python/src/model_registry/client.py
@@ -92,13 +92,9 @@ class ModelRegistry:
         Returns:
             Registered model.
         """
-        py_rm = RegisteredModel.unmap(
+        return RegisteredModel.unmap(
             self._store.get_context(RegisteredModel.get_proto_type_name(), id=int(id))
         )
-        versions = self.get_model_versions(id)
-        assert isinstance(versions, list), "Expected a list"
-        py_rm.versions = versions
-        return py_rm
 
     def get_registered_model_by_params(
         self, name: str | None = None, external_id: str | None = None
@@ -115,18 +111,13 @@ class ModelRegistry:
         if name is None and external_id is None:
             msg = "Either name or external_id must be provided"
             raise StoreException(msg)
-        py_rm = RegisteredModel.unmap(
+        return RegisteredModel.unmap(
             self._store.get_context(
                 RegisteredModel.get_proto_type_name(),
                 name=name,
                 external_id=external_id,
             )
         )
-        assert py_rm.id is not None
-        versions = self.get_model_versions(py_rm.id)
-        assert isinstance(versions, list), "Expected a list"
-        py_rm.versions = versions
-        return py_rm
 
     def get_registered_models(
         self, options: ListOptions | None = None

--- a/clients/python/src/model_registry/types/contexts.py
+++ b/clients/python/src/model_registry/types/contexts.py
@@ -105,11 +105,9 @@ class RegisteredModel(BaseContext):
         name: Registered model name.
         description: Description of the object.
         external_id: Customizable ID. Has to be unique among instances of the same type.
-        versions: Versions associated with this model.
     """
 
     name: str
-    versions: list[ModelVersion] = field(init=False, factory=list)
 
     @classmethod
     @override

--- a/clients/python/src/model_registry/types/contexts.py
+++ b/clients/python/src/model_registry/types/contexts.py
@@ -19,7 +19,7 @@ from typing_extensions import override
 
 from model_registry.store import ScalarType
 
-from .artifacts import BaseArtifact, ModelArtifact
+from .artifacts import BaseArtifact
 from .base import Prefixable, ProtoBase
 
 
@@ -38,7 +38,7 @@ class ModelVersion(BaseContext, Prefixable):
     """Represents a model version.
 
     Attributes:
-        model: Model associated with this version.
+        model_name: Name of the model associated with this version.
         version: Version of the model.
         author: Author of the model version.
         description: Description of the object.
@@ -48,7 +48,7 @@ class ModelVersion(BaseContext, Prefixable):
         metadata: Metadata associated with this version.
     """
 
-    model: ModelArtifact
+    model_name: str
     version: str
     author: str
     artifacts: list[BaseArtifact] = field(init=False, factory=list)
@@ -72,7 +72,7 @@ class ModelVersion(BaseContext, Prefixable):
     def map(self, type_id: int) -> Context:
         mlmd_obj = super().map(type_id)
         # this should match the name of the registered model
-        mlmd_obj.properties["model_name"].string_value = self.model.name
+        mlmd_obj.properties["model_name"].string_value = self.model_name
         mlmd_obj.properties["author"].string_value = self.author
         if self.tags:
             mlmd_obj.properties["tags"].string_value = ",".join(self.tags)
@@ -87,6 +87,7 @@ class ModelVersion(BaseContext, Prefixable):
             py_obj, ModelVersion
         ), f"Expected ModelVersion, got {type(py_obj)}"
         py_obj.version = py_obj.name
+        py_obj.model_name = mlmd_obj.properties["model_name"].string_value
         py_obj.author = mlmd_obj.properties["author"].string_value
         tags = mlmd_obj.properties["tags"].string_value
         if tags:

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -103,16 +103,8 @@ def test_upsert_registered_model(
 def test_get_registered_model_by_id(
     model_registry: ModelRegistry,
     registered_model: Mapped,
-    model_version: Mapped,
 ):
-    model_version.proto.name = f"1:{model_version.proto.name}"
-    mv_id = model_registry._store._mlmd_store.put_contexts([model_version.proto])[0]
-
     rm_id = model_registry._store._mlmd_store.put_contexts([registered_model.proto])[0]
-
-    model_registry._store._mlmd_store.put_parent_contexts(
-        [ParentContext(parent_id=rm_id, child_id=mv_id)]
-    )
 
     mlmd_rm = model_registry.get_registered_model_by_id(str(rm_id))
     assert mlmd_rm.id == str(rm_id)
@@ -123,16 +115,8 @@ def test_get_registered_model_by_id(
 def test_get_registered_model_by_name(
     model_registry: ModelRegistry,
     registered_model: Mapped,
-    model_version: Mapped,
 ):
-    model_version.proto.name = f"1:{model_version.proto.name}"
-    mv_id = model_registry._store._mlmd_store.put_contexts([model_version.proto])[0]
-
     rm_id = model_registry._store._mlmd_store.put_contexts([registered_model.proto])[0]
-
-    model_registry._store._mlmd_store.put_parent_contexts(
-        [ParentContext(parent_id=rm_id, child_id=mv_id)]
-    )
 
     mlmd_rm = model_registry.get_registered_model_by_params(
         name=registered_model.py.name
@@ -145,19 +129,10 @@ def test_get_registered_model_by_name(
 def test_get_registered_model_by_external_id(
     model_registry: ModelRegistry,
     registered_model: Mapped,
-    model_version: Mapped,
 ):
-    model_version.proto.name = f"1:{model_version.proto.name}"
-    mv_id = model_registry._store._mlmd_store.put_contexts([model_version.proto])[0]
-
     registered_model.py.external_id = "external_id"
     registered_model.proto.external_id = "external_id"
-
     rm_id = model_registry._store._mlmd_store.put_contexts([registered_model.proto])[0]
-
-    model_registry._store._mlmd_store.put_parent_contexts(
-        [ParentContext(parent_id=rm_id, child_id=mv_id)]
-    )
 
     mlmd_rm = model_registry.get_registered_model_by_params(
         external_id=registered_model.py.external_id

--- a/clients/python/tests/types/test_context_mapping.py
+++ b/clients/python/tests/types/test_context_mapping.py
@@ -6,7 +6,7 @@ Todo:
 
 import pytest
 from ml_metadata.proto import Context
-from model_registry.types import ModelArtifact, ModelVersion
+from model_registry.types import ModelVersion
 
 from .. import Mapped
 
@@ -26,10 +26,8 @@ def full_model_version() -> Mapped:
     proto_version.custom_properties["bool_key"].bool_value = True
     proto_version.custom_properties["str_key"].string_value = "test_str"
 
-    py_model = ModelArtifact("test_model", "test_uri")
-
     py_version = ModelVersion(
-        py_model,
+        "test_model",
         "1.0.0",
         "test_author",
         external_id="test_external_id",
@@ -54,9 +52,7 @@ def minimal_model_version() -> Mapped:
     proto_version.properties["model_name"].string_value = "test_model"
     proto_version.properties["author"].string_value = "test_author"
 
-    py_model = ModelArtifact("test_model", "test_uri")
-
-    py_version = ModelVersion(py_model, "1.0.0", "test_author")
+    py_version = ModelVersion("test_model", "1.0.0", "test_author")
     py_version._registered_model_id = 1
     return Mapped(proto_version, py_version)
 
@@ -79,21 +75,23 @@ def test_full_model_version_mapping(full_model_version: Mapped):
     assert mapped_version.custom_properties == proto_version.custom_properties
 
 
+def test_partial_model_version_unmapping(minimal_model_version: Mapped):
+    unmapped_version = ModelVersion.unmap(minimal_model_version.proto)
+    py_version = minimal_model_version.py
+    assert unmapped_version.version == py_version.version
+    assert unmapped_version.model_name == py_version.model_name
+    assert unmapped_version.author == py_version.author
+    assert unmapped_version.tags == py_version.tags
+    assert unmapped_version.metadata == py_version.metadata
+
+
 def test_full_model_version_unmapping(full_model_version: Mapped):
     unmapped_version = ModelVersion.unmap(full_model_version.proto)
     py_version = full_model_version.py
     assert unmapped_version.version == py_version.version
     assert unmapped_version.description == py_version.description
     assert unmapped_version.external_id == py_version.external_id
-    assert unmapped_version.author == py_version.author
-    assert unmapped_version.tags == py_version.tags
-    assert unmapped_version.metadata == py_version.metadata
-
-
-def test_partial_model_version_unmapping(minimal_model_version: Mapped):
-    unmapped_version = ModelVersion.unmap(minimal_model_version.proto)
-    py_version = minimal_model_version.py
-    assert unmapped_version.version == py_version.version
+    assert unmapped_version.model_name == py_version.model_name
     assert unmapped_version.author == py_version.author
     assert unmapped_version.tags == py_version.tags
     assert unmapped_version.metadata == py_version.metadata


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Makes ModelVersion and RegisteredModel simpler by removing dependencies on related types. Note that MV still depends on BaseArtifact, but this mapping is not yet done as the user still can't push those objects to the store.

Tests were updated to match the new implementation. In the end, the code is simplified.

Closes: #206

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
