### PR TITLE
Introduce higher-level API for py client

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -3,148 +3,29 @@
 [![Python](https://img.shields.io/badge/python%20-3.9%7C3.10-blue)](https://github.com/opendatahub-io/model-registry)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](../../../LICENSE)
 
-This library provides a low level interface for interacting with a model registry server.
-
-Types are based on [ML Metadata](https://github.com/google/ml-metadata), with Pythonic class wrappers.
+This library provides a high level interface for interacting with a model registry server.
 
 ## Basic usage
-
-### Create objects
-
-Registry objects can be created by doing
-
-<!-- TODO: #120 Refer to types documentation -->
-
-
-```py
-from model_registry.types import ModelArtifact, ModelVersion, RegisteredModel
-
-trained_model = ModelArtifact("my_model_name", "resource_URI",
-                              description="Model description")
-
-version = ModelVersion(trained_model, "v1.0", "model author")
-
-model = RegisteredModel("my_model_name")
-```
-
-### Register objects
-
-<!-- TODO: #120 provide a link to the reference docs instead of code -->
-To register those objects, you can use the [`model_registry.ModelRegistry` class](src/model_registry/registry/client.py):
 
 ```py
 from model_registry import ModelRegistry
 
-registry = ModelRegistry("server-address", "port")
+registry = ModelRegistry(address="server-address", port="port", author="author")
 
-model_id = registry.upsert_registered_model(model)
+model = registry.register_model("my-model",
+                                "s3://path/to/model",
+                                format_name="onnx",
+                                format_version="v1",
+                                secret_account_name="access",
+                                version="v2.0",
+                                description="lorem ipsum",
+                                )
 
-# we need a model to associate the version to
-version_id = registry.upsert_model_version(version, model_id)
+model = registry.get_registered_model("my-model")
 
-# we need a version to associate an trained model to
-experiment_id = registry.upsert_model_artifact(trained_model, version_id)
-```
+version = registry.get_model_version("my-model", "v2.0")
 
-### Query objects
-
-There are several ways to get previously registered objects from the registry.
-
-#### By ID
-
-IDs are created once the object is registered, you can either keep the string returned by the
-`upsert_*` functions, or access the `id` property of the objects.
-
-```py
-new_model = RegisteredModel("new_model")
-
-new_model_id = registry.upsert_registered_model(new_model)
-
-assert new_model_id == new_model.id
-```
-
-To query objects using IDs, do
-
-```py
-another_model = registry.get_registered_model_by_id("another-model-id")
-
-another_version = registry.get_model_version_by_id("another-version-id", another_model.id)
-
-another_trained_model = registry.get_model_artifact_by_id("another-model-artifact-id")
-```
-
-#### By parameters
-
-<!-- TODO: #120 provide a link to the reference docs instead of code -->
-External IDs can be used to query objects in the wild.
-Note that external IDs must be unique among [artifacts](src/model_registry/types/artifacts.py) or
-[contexts](src/model_registry/types/contexts.py).
-
-```py
-trained_model = ModelArtifact("my_model_name", "resource_URI",
-                              description="Model description",
-                              external_id="unique_reference")
-
-# As a version is a context, we can have the same external_id as the above
-version = ModelVersion(trained_model, "v1.0", "model author",
-                       external_id="unique_reference")
-
-# Registering this will cause an error!
-# model = RegisteredModel("my_model_name",
-#                         external_id="unique_reference")
-
-model = RegisteredModel("my_model_name",
-                        external_id="another_unique_reference")
-```
-
-You can also perform queries by parameters:
-
-```py
-# We can get the model artifact associated to a version
-another_trained_model = registry.get_model_artifact_by_params(model_version_id=another_version.id)
-
-# Or by its unique identifier
-trained_model = registry.get_model_artifact_by_params(external_id="unique_reference")
-
-# Same thing for a version
-version = registry.get_model_version_by_params(external_id="unique_reference")
-
-# Or for a model
-model = registry.get_registered_model_by_params(external_id="another_unique_reference")
-
-# We can also get a version by its name and associated model id
-version = registry.get_model_version_by_params(version="v1.0", registered_model_id="x")
-
-# And we can get a model by simply calling its name
-model = registry.get_registered_model_by_params(name="my_model_name")
-```
-
-### Query multiple objects
-
-We can query all objects of a type
-
-```py
-models = registry.get_registered_models()
-
-versions = registry.get_model_versions("registered_model_id")
-
-# We can get a list of all model artifacts
-all_model_artifacts = registry.get_model_artifacts()
-```
-
-To limit or order the query, provide a [`ListOptions`](src/model_registry/types/options.py) object
-
-```py
-from model_registry import ListOptions, OrderByField
-
-options = ListOptions(limit=50)
-
-first_50_models = registry.get_registered_models(options)
-
-# By default we get ascending order
-options = ListOptions(order_by=OrderByField.CREATE_TIME, is_asc=False)
-
-last_50_models = registry.get_registered_models(options)
+experiment = registry.get_model_artifact("my-model", "v2.0")
 ```
 
 ## Development

--- a/clients/python/docs/reference.md
+++ b/clients/python/docs/reference.md
@@ -3,10 +3,148 @@
 ## Client
 
 ```{eval-rst}
-.. automodule:: model_registry.client
+.. automodule:: model_registry
+```
+
+## Core
+
+### Register objects
+
+```py
+from model_registry import ModelRegistry
+
+registry = ModelRegistry("server-address", "port")
+
+model_id = registry.upsert_registered_model(model)
+
+# we need a model to associate the version to
+version_id = registry.upsert_model_version(version, model_id)
+
+# we need a version to associate an trained model to
+experiment_id = registry.upsert_model_artifact(trained_model, version_id)
+```
+
+### Query objects
+
+There are several ways to get previously registered objects from the registry.
+
+#### By ID
+
+IDs are created once the object is registered, you can either keep the string returned by the
+`upsert_*` functions, or access the `id` property of the objects.
+
+```py
+new_model = RegisteredModel("new_model")
+
+new_model_id = registry.upsert_registered_model(new_model)
+
+assert new_model_id == new_model.id
+```
+
+To query objects using IDs, do
+
+```py
+another_model = registry.get_registered_model_by_id("another-model-id")
+
+another_version = registry.get_model_version_by_id("another-version-id", another_model.id)
+
+another_trained_model = registry.get_model_artifact_by_id("another-model-artifact-id")
+```
+
+#### By parameters
+
+External IDs can be used to query objects in the wild.
+Note that external IDs must be unique among artifacts or
+contexts (see [Types](#types)).
+
+```py
+trained_model = ModelArtifact("my_model_name", "resource_URI",
+                              description="Model description",
+                              external_id="unique_reference")
+
+# As a version is a context, we can have the same external_id as the above
+version = ModelVersion(trained_model, "v1.0", "model author",
+                       external_id="unique_reference")
+
+# Registering this will cause an error!
+# model = RegisteredModel("my_model_name",
+#                         external_id="unique_reference")
+
+model = RegisteredModel("my_model_name",
+                        external_id="another_unique_reference")
+```
+
+You can also perform queries by parameters:
+
+```py
+# We can get the model artifact associated to a version
+another_trained_model = registry.get_model_artifact_by_params(model_version_id=another_version.id)
+
+# Or by its unique identifier
+trained_model = registry.get_model_artifact_by_params(external_id="unique_reference")
+
+# Same thing for a version
+version = registry.get_model_version_by_params(external_id="unique_reference")
+
+# Or for a model
+model = registry.get_registered_model_by_params(external_id="another_unique_reference")
+
+# We can also get a version by its name and associated model id
+version = registry.get_model_version_by_params(version="v1.0", registered_model_id="x")
+
+# And we can get a model by simply calling its name
+model = registry.get_registered_model_by_params(name="my_model_name")
+```
+
+### Query multiple objects
+
+We can query all objects of a type
+
+```py
+models = registry.get_registered_models()
+
+versions = registry.get_model_versions("registered_model_id")
+
+# We can get a list of all model artifacts
+all_model_artifacts = registry.get_model_artifacts()
+```
+
+<!-- TODO: #120 provide a link to the reference docs instead of code -->
+To limit or order the query, provide a `ListOptions` object
+
+```py
+from model_registry import ListOptions, OrderByField
+
+options = ListOptions(limit=50)
+
+first_50_models = registry.get_registered_models(options)
+
+# By default we get ascending order
+options = ListOptions(order_by=OrderByField.CREATE_TIME, is_asc=False)
+
+last_50_models = registry.get_registered_models(options)
+```
+
+```{eval-rst}
+.. automodule:: model_registry.core
 ```
 
 ## Types
+
+### Create objects
+
+Registry objects can be created by doing
+
+```py
+from model_registry.types import ModelArtifact, ModelVersion, RegisteredModel
+
+trained_model = ModelArtifact("my_model_name", "resource_URI",
+                              description="Model description")
+
+version = ModelVersion(trained_model.name, "v1.0", "model author")
+
+model = RegisteredModel(trained_model.name)
+```
 
 ```{eval-rst}
 .. automodule:: model_registry.types

--- a/clients/python/src/model_registry/__init__.py
+++ b/clients/python/src/model_registry/__init__.py
@@ -2,11 +2,8 @@
 
 __version__ = "0.1.0"
 
-from .client import ModelRegistry
-from .types import ListOptions, OrderByField
+from ._client import ModelRegistry
 
 __all__ = [
     "ModelRegistry",
-    "ListOptions",
-    "OrderByField",
 ]

--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -1,0 +1,148 @@
+"""Standard client for the model registry."""
+from __future__ import annotations
+
+from .core import ModelRegistryAPIClient
+from .exceptions import StoreException
+from .types import ModelArtifact, ModelVersion, RegisteredModel
+
+
+class ModelRegistry:
+    """Model registry client."""
+
+    def __init__(
+        self,
+        server_address: str,
+        port: int,
+        author: str,
+        client_key: str | None = None,
+        server_cert: str | None = None,
+        custom_ca: str | None = None,
+    ):
+        """Constructor.
+
+        Args:
+            server_address (str): Server address.
+            port (int): Server port.
+            author (str): Name of the author.
+            client_key (str, optional): The PEM-encoded private key as a byte string.
+            server_cert (str, optional): The PEM-encoded certificate as a byte string.
+            custom_ca (str, optional): The PEM-encoded root certificates as a byte string.
+        """
+        # TODO: get args from env
+        self._author = author
+        self._api = ModelRegistryAPIClient(
+            server_address, port, client_key, server_cert, custom_ca
+        )
+
+    def _register_model(self, name: str) -> RegisteredModel:
+        if rm := self._api.get_registered_model_by_params(name):
+            return rm
+
+        rm = RegisteredModel(name)
+        self._api.upsert_registered_model(rm)
+        return rm
+
+    def _register_new_version(
+        self, rm: RegisteredModel, version: str, /, description: str | None
+    ) -> ModelVersion:
+        assert rm.id is not None, "Registered model must have an ID"
+        if self._api.get_model_version_by_params(rm.id, version):
+            msg = f"Version {version} already exists"
+            raise StoreException(msg)
+
+        mv = ModelVersion(rm.name, version, self._author, description=description)
+        self._api.upsert_model_version(mv, rm.id)
+        return mv
+
+    def _register_model_artifact(
+        self, mv: ModelVersion, uri: str, /, **kwargs
+    ) -> ModelArtifact:
+        assert mv.id is not None, "Model version must have an ID"
+        ma = ModelArtifact(mv.model_name, uri, **kwargs)
+        self._api.upsert_model_artifact(ma, mv.id)
+        return ma
+
+    def register_model(
+        self,
+        name: str,
+        uri: str,
+        *,
+        model_format_name: str,
+        model_format_version: str,
+        version: str,
+        description: str | None = None,
+        storage_key: str | None = None,
+        storage_path: str | None = None,
+        service_account_name: str | None = None,
+    ) -> RegisteredModel:
+        """Register a model.
+
+        Version has to be unique for the model.
+        Either `storage_key` and `storage_path`, or `service_account_name` must be provided.
+
+        Args:
+            name (str): Name of the model.
+            uri (str): URI of the model.
+
+        Keyword Args:
+            model_format_name (str): Name of the model format.
+            model_format_version (str): Version of the model format.
+            version (str): Version of the model.
+            description (str, optional): Description of the model.
+            storage_key (str, optional): Storage key.
+            storage_path (str, optional): Storage path.
+            service_account_name (str, optional): Service account name.
+
+        Returns:
+            RegisteredModel: Registered model.
+        """
+        rm = self._register_model(name)
+        mv = self._register_new_version(rm, version, description=description)
+        self._register_model_artifact(
+            mv,
+            uri,
+            model_format_name=model_format_name,
+            model_format_version=model_format_version,
+            storage_key=storage_key,
+            storage_path=storage_path,
+            service_account_name=service_account_name,
+        )
+
+        return rm
+
+    def get_registered_model(self, name: str) -> RegisteredModel:
+        """Get a registered model.
+
+        Args:
+            name (str): Name of the model.
+
+        Returns:
+            RegisteredModel: Registered model.
+        """
+        return self._api.get_registered_model_by_params(name)
+
+    def get_model_version(self, name: str, version: str) -> ModelVersion:
+        """Get a model version.
+
+        Args:
+            name (str): Name of the model.
+            version (str): Version of the model.
+
+        Returns:
+            ModelVersion: Model version.
+        """
+        rm = self._api.get_registered_model_by_params(name)
+        return self._api.get_model_version_by_params(rm.id, version)
+
+    def get_model_artifact(self, name: str, version: str) -> ModelArtifact:
+        """Get a model artifact.
+
+        Args:
+            name (str): Name of the model.
+            version (str): Version of the model.
+
+        Returns:
+            ModelArtifact: Model artifact.
+        """
+        mv = self.get_model_version(name, version)
+        return self._api.get_model_artifact_by_params(mv.id)

--- a/clients/python/src/model_registry/client.py
+++ b/clients/python/src/model_registry/client.py
@@ -83,7 +83,7 @@ class ModelRegistry:
         )
         return id
 
-    def get_registered_model_by_id(self, id: str) -> RegisteredModel:
+    def get_registered_model_by_id(self, id: str) -> RegisteredModel | None:
         """Fetch a registered model by its ID.
 
         Args:
@@ -92,13 +92,17 @@ class ModelRegistry:
         Returns:
             Registered model.
         """
-        return RegisteredModel.unmap(
-            self._store.get_context(RegisteredModel.get_proto_type_name(), id=int(id))
+        proto_rm = self._store.get_context(
+            RegisteredModel.get_proto_type_name(), id=int(id)
         )
+        if proto_rm is not None:
+            return RegisteredModel.unmap(proto_rm)
+
+        return None
 
     def get_registered_model_by_params(
         self, name: str | None = None, external_id: str | None = None
-    ) -> RegisteredModel:
+    ) -> RegisteredModel | None:
         """Fetch a registered model by its name or external ID.
 
         Args:
@@ -111,13 +115,15 @@ class ModelRegistry:
         if name is None and external_id is None:
             msg = "Either name or external_id must be provided"
             raise StoreException(msg)
-        return RegisteredModel.unmap(
-            self._store.get_context(
-                RegisteredModel.get_proto_type_name(),
-                name=name,
-                external_id=external_id,
-            )
+        proto_rm = self._store.get_context(
+            RegisteredModel.get_proto_type_name(),
+            name=name,
+            external_id=external_id,
         )
+        if proto_rm is not None:
+            return RegisteredModel.unmap(proto_rm)
+
+        return None
 
     def get_registered_models(
         self, options: ListOptions | None = None
@@ -176,11 +182,13 @@ class ModelRegistry:
         Returns:
             Model version.
         """
-        return ModelVersion.unmap(
-            self._store.get_context(
-                ModelVersion.get_proto_type_name(), id=int(model_version_id)
-            )
+        proto_mv = self._store.get_context(
+            ModelVersion.get_proto_type_name(), id=int(model_version_id)
         )
+        if proto_mv is not None:
+            return ModelVersion.unmap(proto_mv)
+
+        return None
 
     def get_model_versions(
         self, registered_model_id: str, options: ListOptions | None = None
@@ -208,7 +216,7 @@ class ModelRegistry:
         registered_model_id: str | None = None,
         version: str | None = None,
         external_id: str | None = None,
-    ) -> ModelVersion:
+    ) -> ModelVersion | None:
         """Fetch a model version by associated parameters.
 
         Either fetches by using external ID or by using registered model ID and version.
@@ -235,7 +243,10 @@ class ModelRegistry:
                 ModelVersion.get_proto_type_name(),
                 name=f"{registered_model_id}:{version}",
             )
-        return ModelVersion.unmap(proto_mv)
+        if proto_mv is not None:
+            return ModelVersion.unmap(proto_mv)
+
+        return None
 
     def upsert_model_artifact(
         self, model_artifact: ModelArtifact, model_version_id: str
@@ -276,7 +287,7 @@ class ModelRegistry:
         )
         return id
 
-    def get_model_artifact_by_id(self, id: str) -> ModelArtifact:
+    def get_model_artifact_by_id(self, id: str) -> ModelArtifact | None:
         """Fetch a model artifact by its ID.
 
         Args:
@@ -288,11 +299,14 @@ class ModelRegistry:
         proto_ma = self._store.get_artifact(
             ModelArtifact.get_proto_type_name(), int(id)
         )
-        return ModelArtifact.unmap(proto_ma)
+        if proto_ma is not None:
+            return ModelArtifact.unmap(proto_ma)
+
+        return None
 
     def get_model_artifact_by_params(
         self, model_version_id: str | None = None, external_id: str | None = None
-    ) -> ModelArtifact:
+    ) -> ModelArtifact | None:
         """Fetch a model artifact either by external ID or by the ID of its associated model version.
 
         Args:
@@ -313,7 +327,10 @@ class ModelRegistry:
             proto_ma = self._store.get_attributed_artifact(
                 ModelArtifact.get_proto_type_name(), int(model_version_id)
             )
-        return ModelArtifact.unmap(proto_ma)
+        if proto_ma is not None:
+            return ModelArtifact.unmap(proto_ma)
+
+        return None
 
     def get_model_artifacts(
         self,

--- a/clients/python/src/model_registry/core.py
+++ b/clients/python/src/model_registry/core.py
@@ -12,8 +12,8 @@ from .types.base import ProtoBase
 from .types.options import MLMDListOptions
 
 
-class ModelRegistry:
-    """Model registry client."""
+class ModelRegistryAPIClient:
+    """Model registry API."""
 
     def __init__(
         self,

--- a/clients/python/src/model_registry/store/wrapper.py
+++ b/clients/python/src/model_registry/store/wrapper.py
@@ -144,7 +144,7 @@ class MLMDStore:
         id: int | None = None,
         name: str | None = None,
         external_id: str | None = None,
-    ) -> Context:
+    ) -> Context | None:
         """Get a context from the store.
 
         This gets a context either by ID, name or external ID.
@@ -160,7 +160,7 @@ class MLMDStore:
             Context.
 
         Raises:
-            StoreException: If the context doesn't exist.
+            StoreException: Invalid arguments.
         """
         if name is not None:
             return self._mlmd_store.get_context_by_type_and_name(ctx_type_name, name)
@@ -177,8 +177,7 @@ class MLMDStore:
         if contexts:
             return contexts[0]
 
-        msg = f"Context with ID {id} does not exist"
-        raise StoreException(msg)
+        return None
 
     def get_contexts(
         self, ctx_type_name: str, options: ListOptions
@@ -266,7 +265,7 @@ class MLMDStore:
         id: int | None = None,
         name: str | None = None,
         external_id: str | None = None,
-    ) -> Artifact:
+    ) -> Artifact | None:
         """Get an artifact from the store.
 
         Gets an artifact either by ID, name or external ID.
@@ -281,7 +280,7 @@ class MLMDStore:
             Artifact.
 
         Raises:
-            StoreException: If the context doesn't exist.
+            StoreException: Invalid arguments.
         """
         if name is not None:
             return self._mlmd_store.get_artifact_by_type_and_name(art_type_name, name)
@@ -298,8 +297,7 @@ class MLMDStore:
         if artifacts:
             return artifacts[0]
 
-        msg = f"Artifact with ID {id} does not exist"
-        raise StoreException(msg)
+        return None
 
     def get_attributed_artifact(self, art_type_name: str, ctx_id: int) -> Artifact:
         """Get an artifact from the store by its attributed context.

--- a/clients/python/src/model_registry/types/__init__.py
+++ b/clients/python/src/model_registry/types/__init__.py
@@ -1,4 +1,7 @@
-"""Model registry types."""
+"""Model registry types.
+
+Types are based on [ML Metadata](https://github.com/google/ml-metadata), with Pythonic class wrappers.
+"""
 
 from .artifacts import ArtifactState, ModelArtifact
 from .contexts import ModelVersion, RegisteredModel

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -1,10 +1,70 @@
+from typing import Union
+
 import pytest
-from ml_metadata.proto import ConnectionConfig
+from ml_metadata.proto import (
+    ArtifactType,
+    ConnectionConfig,
+    ContextType,
+    metadata_store_pb2,
+)
 from model_registry.store.wrapper import MLMDStore
+from model_registry.types import ModelArtifact, ModelVersion, RegisteredModel
 
 
 @pytest.fixture()
-def store_wrapper() -> MLMDStore:
+def plain_wrapper() -> MLMDStore:
     config = ConnectionConfig()
     config.fake_database.SetInParent()
     return MLMDStore(config)
+
+
+def set_type_attrs(
+    mlmd_obj: Union[ArtifactType, ContextType], name: str, props: list[str]
+):
+    mlmd_obj.name = name
+    for key in props:
+        mlmd_obj.properties[key] = metadata_store_pb2.STRING
+    return mlmd_obj
+
+
+@pytest.fixture()
+def store_wrapper(plain_wrapper: MLMDStore) -> MLMDStore:
+    ma_type = set_type_attrs(
+        ArtifactType(),
+        ModelArtifact.get_proto_type_name(),
+        [
+            "description",
+            "model_format_name",
+            "model_format_version",
+            "storage_key",
+            "storage_path",
+            "service_account_name",
+        ],
+    )
+
+    plain_wrapper._mlmd_store.put_artifact_type(ma_type)
+
+    mv_type = set_type_attrs(
+        ContextType(),
+        ModelVersion.get_proto_type_name(),
+        [
+            "author",
+            "description",
+            "model_name",
+            "tags",
+        ],
+    )
+
+    plain_wrapper._mlmd_store.put_context_type(mv_type)
+
+    rm_type = set_type_attrs(
+        ContextType(),
+        RegisteredModel.get_proto_type_name(),
+        [
+            "description",
+        ],
+    )
+
+    plain_wrapper._mlmd_store.put_context_type(rm_type)
+
+    return plain_wrapper

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -7,8 +7,11 @@ from ml_metadata.proto import (
     ContextType,
     metadata_store_pb2,
 )
+from model_registry.core import ModelRegistryAPIClient
 from model_registry.store.wrapper import MLMDStore
 from model_registry.types import ModelArtifact, ModelVersion, RegisteredModel
+
+ProtoTypeType = Union[ArtifactType, ContextType]
 
 
 @pytest.fixture()
@@ -18,9 +21,7 @@ def plain_wrapper() -> MLMDStore:
     return MLMDStore(config)
 
 
-def set_type_attrs(
-    mlmd_obj: Union[ArtifactType, ContextType], name: str, props: list[str]
-):
+def set_type_attrs(mlmd_obj: ProtoTypeType, name: str, props: list[str]):
     mlmd_obj.name = name
     for key in props:
         mlmd_obj.properties[key] = metadata_store_pb2.STRING
@@ -68,3 +69,10 @@ def store_wrapper(plain_wrapper: MLMDStore) -> MLMDStore:
     plain_wrapper._mlmd_store.put_context_type(rm_type)
 
     return plain_wrapper
+
+
+@pytest.fixture()
+def mr_api(store_wrapper: MLMDStore) -> ModelRegistryAPIClient:
+    mr = object.__new__(ModelRegistryAPIClient)
+    mr._store = store_wrapper
+    return mr

--- a/clients/python/tests/store/test_wrapper.py
+++ b/clients/python/tests/store/test_wrapper.py
@@ -103,10 +103,8 @@ def test_put_attribution_with_invalid_artifact(
 
 
 def test_get_undefined_artifact_by_id(store_wrapper: MLMDStore):
-    with pytest.raises(StoreException):
-        store_wrapper.get_artifact("dup", 0)
+    assert store_wrapper.get_artifact("dup", 0) is None
 
 
 def test_get_undefined_context_by_id(store_wrapper: MLMDStore):
-    with pytest.raises(StoreException):
-        store_wrapper.get_context("dup", 0)
+    assert store_wrapper.get_context("dup", 0) is None

--- a/clients/python/tests/store/test_wrapper.py
+++ b/clients/python/tests/store/test_wrapper.py
@@ -20,91 +20,91 @@ from model_registry.store import MLMDStore
 
 
 @pytest.fixture()
-def artifact(store_wrapper: MLMDStore) -> Artifact:
+def artifact(plain_wrapper: MLMDStore) -> Artifact:
     art_type = ArtifactType()
     art_type.name = "test_artifact"
 
     art = Artifact()
     art.name = "test_artifact"
-    art.type_id = store_wrapper._mlmd_store.put_artifact_type(art_type)
+    art.type_id = plain_wrapper._mlmd_store.put_artifact_type(art_type)
 
     return art
 
 
 @pytest.fixture()
-def context(store_wrapper: MLMDStore) -> Context:
+def context(plain_wrapper: MLMDStore) -> Context:
     ctx_type = ContextType()
     ctx_type.name = "test_context"
 
     ctx = Context()
     ctx.name = "test_context"
-    ctx.type_id = store_wrapper._mlmd_store.put_context_type(ctx_type)
+    ctx.type_id = plain_wrapper._mlmd_store.put_context_type(ctx_type)
 
     return ctx
 
 
-def test_get_undefined_artifact_type_id(store_wrapper: MLMDStore):
+def test_get_undefined_artifact_type_id(plain_wrapper: MLMDStore):
     with pytest.raises(TypeNotFoundException):
-        store_wrapper.get_type_id(Artifact, "undefined")
+        plain_wrapper.get_type_id(Artifact, "undefined")
 
 
-def test_get_undefined_context_type_id(store_wrapper: MLMDStore):
+def test_get_undefined_context_type_id(plain_wrapper: MLMDStore):
     with pytest.raises(TypeNotFoundException):
-        store_wrapper.get_type_id(Context, "undefined")
+        plain_wrapper.get_type_id(Context, "undefined")
 
 
-def test_put_invalid_artifact(store_wrapper: MLMDStore, artifact: Artifact):
+def test_put_invalid_artifact(plain_wrapper: MLMDStore, artifact: Artifact):
     artifact.properties["null"].int_value = 0
 
     with pytest.raises(StoreException):
-        store_wrapper.put_artifact(artifact)
+        plain_wrapper.put_artifact(artifact)
 
 
-def test_put_duplicate_artifact(store_wrapper: MLMDStore, artifact: Artifact):
-    store_wrapper._mlmd_store.put_artifacts([artifact])
+def test_put_duplicate_artifact(plain_wrapper: MLMDStore, artifact: Artifact):
+    plain_wrapper._mlmd_store.put_artifacts([artifact])
     with pytest.raises(DuplicateException):
-        store_wrapper.put_artifact(artifact)
+        plain_wrapper.put_artifact(artifact)
 
 
-def test_put_invalid_context(store_wrapper: MLMDStore, context: Context):
+def test_put_invalid_context(plain_wrapper: MLMDStore, context: Context):
     context.properties["null"].int_value = 0
 
     with pytest.raises(StoreException):
-        store_wrapper.put_context(context)
+        plain_wrapper.put_context(context)
 
 
-def test_put_duplicate_context(store_wrapper: MLMDStore, context: Context):
-    store_wrapper._mlmd_store.put_contexts([context])
+def test_put_duplicate_context(plain_wrapper: MLMDStore, context: Context):
+    plain_wrapper._mlmd_store.put_contexts([context])
 
     with pytest.raises(DuplicateException):
-        store_wrapper.put_context(context)
+        plain_wrapper.put_context(context)
 
 
 def test_put_attribution_with_invalid_context(
-    store_wrapper: MLMDStore, artifact: Artifact
+    plain_wrapper: MLMDStore, artifact: Artifact
 ):
-    art_id = store_wrapper._mlmd_store.put_artifacts([artifact])[0]
+    art_id = plain_wrapper._mlmd_store.put_artifacts([artifact])[0]
 
     with pytest.raises(StoreException) as store_error:
-        store_wrapper.put_attribution(0, art_id)
+        plain_wrapper.put_attribution(0, art_id)
 
     assert "context" in str(store_error.value).lower()
 
 
 def test_put_attribution_with_invalid_artifact(
-    store_wrapper: MLMDStore, context: Context
+    plain_wrapper: MLMDStore, context: Context
 ):
-    ctx_id = store_wrapper._mlmd_store.put_contexts([context])[0]
+    ctx_id = plain_wrapper._mlmd_store.put_contexts([context])[0]
 
     with pytest.raises(StoreException) as store_error:
-        store_wrapper.put_attribution(ctx_id, 0)
+        plain_wrapper.put_attribution(ctx_id, 0)
 
     assert "artifact" in str(store_error.value).lower()
 
 
-def test_get_undefined_artifact_by_id(store_wrapper: MLMDStore):
-    assert store_wrapper.get_artifact("dup", 0) is None
+def test_get_undefined_artifact_by_id(plain_wrapper: MLMDStore):
+    assert plain_wrapper.get_artifact("dup", 0) is None
 
 
-def test_get_undefined_context_by_id(store_wrapper: MLMDStore):
-    assert store_wrapper.get_context("dup", 0) is None
+def test_get_undefined_context_by_id(plain_wrapper: MLMDStore):
+    assert plain_wrapper.get_context("dup", 0) is None

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -1,347 +1,65 @@
-"""Tests for user facing model registry APIs."""
-
 import pytest
-from attrs import evolve
-from ml_metadata.proto import (
-    Artifact,
-    Attribution,
-    Context,
-    ParentContext,
-)
 from model_registry import ModelRegistry
+from model_registry.core import ModelRegistryAPIClient
 from model_registry.exceptions import StoreException
-from model_registry.store import MLMDStore
-from model_registry.types import ModelArtifact, ModelVersion, RegisteredModel
-
-from . import Mapped
 
 
 @pytest.fixture()
-def model_registry(store_wrapper: MLMDStore) -> ModelRegistry:
-    mr = object.__new__(ModelRegistry)
-    mr._store = store_wrapper
+def mr_client(mr_api: ModelRegistryAPIClient) -> ModelRegistry:
+    mr = ModelRegistry.__new__(ModelRegistry)
+    mr._api = mr_api
+    mr._author = "test_author"
     return mr
 
 
-@pytest.fixture()
-def model(store_wrapper: MLMDStore) -> Mapped:
-    art = Artifact()
-    # we can't test the name directly as it's prefixed
-    art.name = "model"
-    art.type_id = store_wrapper.get_type_id(
-        Artifact, ModelArtifact.get_proto_type_name()
+def test_register_new(mr_client: ModelRegistry):
+    name = "test_model"
+    version = "1.0.0"
+    rm = mr_client.register_model(
+        name,
+        "s3",
+        model_format_name="test_format",
+        model_format_version="test_version",
+        version=version,
     )
-    art.uri = "uri"
+    assert rm.id is not None
 
-    return Mapped(art, ModelArtifact("model", "uri"))
-
-
-@pytest.fixture()
-def model_version(store_wrapper: MLMDStore, model: Mapped) -> Mapped:
-    ctx = Context()
-    # we can't test the name directly as it's prefixed
-    ctx.name = "version"
-    ctx.type_id = store_wrapper.get_type_id(Context, ModelVersion.get_proto_type_name())
-    ctx.properties["author"].string_value = "author"
-    ctx.properties["model_name"].string_value = model.py.name
-
-    return Mapped(ctx, ModelVersion(model.py.name, "version", "author"))
+    mr_api = mr_client._api
+    assert (mv := mr_api.get_model_version_by_params(rm.id, version)) is not None
+    assert mr_api.get_model_artifact_by_params(mv.id) is not None
 
 
-@pytest.fixture()
-def registered_model(store_wrapper: MLMDStore, model: Mapped) -> Mapped:
-    ctx = Context()
-    ctx.name = model.py.name
-    ctx.type_id = store_wrapper.get_type_id(
-        Context, RegisteredModel.get_proto_type_name()
-    )
+def test_register_existing_version(mr_client: ModelRegistry):
+    params = {
+        "name": "test_model",
+        "uri": "s3",
+        "model_format_name": "test_format",
+        "model_format_version": "test_version",
+        "version": "1.0.0",
+    }
+    mr_client.register_model(**params)
 
-    return Mapped(ctx, RegisteredModel(model.py.name))
-
-
-# TODO: should we test insert/update separately?
-def test_upsert_registered_model(
-    model_registry: ModelRegistry, registered_model: Mapped
-):
-    model_registry.upsert_registered_model(registered_model.py)
-
-    rm_proto = model_registry._store._mlmd_store.get_context_by_type_and_name(
-        RegisteredModel.get_proto_type_name(), registered_model.proto.name
-    )
-    assert rm_proto is not None
-    assert registered_model.py.id == str(rm_proto.id)
-    assert registered_model.py.name == rm_proto.name
-
-
-def test_get_registered_model_by_id(
-    model_registry: ModelRegistry,
-    registered_model: Mapped,
-):
-    rm_id = model_registry._store._mlmd_store.put_contexts([registered_model.proto])[0]
-
-    mlmd_rm = model_registry.get_registered_model_by_id(str(rm_id))
-    assert mlmd_rm.id == str(rm_id)
-    assert mlmd_rm.name == registered_model.py.name
-    assert mlmd_rm.name == registered_model.proto.name
-
-
-def test_get_registered_model_by_name(
-    model_registry: ModelRegistry,
-    registered_model: Mapped,
-):
-    rm_id = model_registry._store._mlmd_store.put_contexts([registered_model.proto])[0]
-
-    mlmd_rm = model_registry.get_registered_model_by_params(
-        name=registered_model.py.name
-    )
-    assert mlmd_rm.id == str(rm_id)
-    assert mlmd_rm.name == registered_model.py.name
-    assert mlmd_rm.name == registered_model.proto.name
-
-
-def test_get_registered_model_by_external_id(
-    model_registry: ModelRegistry,
-    registered_model: Mapped,
-):
-    registered_model.py.external_id = "external_id"
-    registered_model.proto.external_id = "external_id"
-    rm_id = model_registry._store._mlmd_store.put_contexts([registered_model.proto])[0]
-
-    mlmd_rm = model_registry.get_registered_model_by_params(
-        external_id=registered_model.py.external_id
-    )
-    assert mlmd_rm.id == str(rm_id)
-    assert mlmd_rm.name == registered_model.py.name
-    assert mlmd_rm.name == registered_model.proto.name
-
-
-def test_get_registered_models(model_registry: ModelRegistry, registered_model: Mapped):
-    rm1_id = model_registry._store._mlmd_store.put_contexts([registered_model.proto])[0]
-    registered_model.proto.name = "model2"
-    rm2_id = model_registry._store._mlmd_store.put_contexts([registered_model.proto])[0]
-
-    mlmd_rms = model_registry.get_registered_models()
-    assert len(mlmd_rms) == 2
-    assert mlmd_rms[0].id in [str(rm1_id), str(rm2_id)]
-
-
-def test_upsert_model_version(
-    model_registry: ModelRegistry, model_version: Mapped, registered_model: Mapped
-):
-    rm_id = model_registry._store._mlmd_store.put_contexts([registered_model.proto])[0]
-    rm_id = str(rm_id)
-
-    model_registry.upsert_model_version(model_version.py, rm_id)
-
-    mv_proto = model_registry._store._mlmd_store.get_context_by_type_and_name(
-        ModelVersion.get_proto_type_name(), f"{rm_id}:{model_version.proto.name}"
-    )
-    assert mv_proto is not None
-    assert model_version.py.id == str(mv_proto.id)
-    assert model_version.py.version != mv_proto.name
-
-
-def test_get_model_version_by_id(model_registry: ModelRegistry, model_version: Mapped):
-    model_version.proto.name = f"1:{model_version.proto.name}"
-    ctx_id = model_registry._store._mlmd_store.put_contexts([model_version.proto])[0]
-
-    id = str(ctx_id)
-    mlmd_mv = model_registry.get_model_version_by_id(id)
-    assert mlmd_mv.id == id
-    assert mlmd_mv.name == model_version.py.name
-    assert mlmd_mv.version != model_version.proto.name
-
-
-def test_get_model_version_by_name(
-    model_registry: ModelRegistry, model_version: Mapped
-):
-    model_version.proto.name = f"1:{model_version.proto.name}"
-    mv_id = model_registry._store._mlmd_store.put_contexts([model_version.proto])[0]
-
-    mlmd_mv = model_registry.get_model_version_by_params(
-        registered_model_id="1", version=model_version.py.name
-    )
-    assert mlmd_mv.id == str(mv_id)
-    assert mlmd_mv.name == model_version.py.name
-    assert mlmd_mv.name != model_version.proto.name
-
-
-def test_get_model_version_by_external_id(
-    model_registry: ModelRegistry, model_version: Mapped
-):
-    model_version.proto.name = f"1:{model_version.proto.name}"
-    model_version.proto.external_id = "external_id"
-    model_version.py.external_id = "external_id"
-    mv_id = model_registry._store._mlmd_store.put_contexts([model_version.proto])[0]
-
-    mlmd_mv = model_registry.get_model_version_by_params(
-        external_id=model_version.py.external_id
-    )
-    assert mlmd_mv.id == str(mv_id)
-    assert mlmd_mv.name == model_version.py.name
-    assert mlmd_mv.name != model_version.proto.name
-
-
-def test_get_model_versions(
-    model_registry: ModelRegistry,
-    model_version: Mapped,
-    registered_model: Mapped,
-):
-    rm_id = model_registry._store._mlmd_store.put_contexts([registered_model.proto])[0]
-
-    model_version.proto.name = f"{rm_id}:version"
-    mv1_id = model_registry._store._mlmd_store.put_contexts([model_version.proto])[0]
-    model_version.proto.name = f"{rm_id}:version2"
-    mv2_id = model_registry._store._mlmd_store.put_contexts([model_version.proto])[0]
-
-    model_registry._store._mlmd_store.put_parent_contexts(
-        [
-            ParentContext(parent_id=rm_id, child_id=mv1_id),
-            ParentContext(parent_id=rm_id, child_id=mv2_id),
-        ]
-    )
-
-    mlmd_mvs = model_registry.get_model_versions(str(rm_id))
-    assert len(mlmd_mvs) == 2
-    assert mlmd_mvs[0].id in [str(mv1_id), str(mv2_id)]
-
-
-def test_upsert_model_artifact(
-    monkeypatch, model_registry: ModelRegistry, model: Mapped, model_version: Mapped
-):
-    monkeypatch.setattr(ModelArtifact, "mlmd_name_prefix", "test_prefix")
-
-    mv_id = model_registry._store._mlmd_store.put_contexts([model_version.proto])[0]
-    mv_id = str(mv_id)
-
-    model_registry.upsert_model_artifact(model.py, mv_id)
-
-    ma_proto = model_registry._store._mlmd_store.get_artifact_by_type_and_name(
-        ModelArtifact.get_proto_type_name(), f"test_prefix:{model.proto.name}"
-    )
-    assert ma_proto is not None
-    assert model.py.id == str(ma_proto.id)
-    assert model.py.name != ma_proto.name
-
-
-def test_upsert_duplicate_model_artifact_with_different_version(
-    model_registry: ModelRegistry, model: Mapped, model_version: Mapped
-):
-    mv1_id = model_registry._store._mlmd_store.put_contexts([model_version.proto])[0]
-    mv1_id = str(mv1_id)
-
-    model_version.proto.name = "version2"
-    mv2_id = model_registry._store._mlmd_store.put_contexts([model_version.proto])[0]
-    mv2_id = str(mv2_id)
-
-    ma1 = evolve(model.py)
-    model_registry.upsert_model_artifact(ma1, mv1_id)
-    ma2 = evolve(model.py)
-    model_registry.upsert_model_artifact(ma2, mv2_id)
-
-    ma_protos = model_registry._store._mlmd_store.get_artifacts_by_id(
-        [int(ma1.id), int(ma2.id)]
-    )
-    assert ma1.name == ma2.name
-    assert ma1.name != str(ma_protos[0].name)
-    assert ma2.name != str(ma_protos[1].name)
-
-
-def test_upsert_duplicate_model_artifact_with_same_version(
-    model_registry: ModelRegistry, model: Mapped, model_version: Mapped
-):
-    mv_id = model_registry._store._mlmd_store.put_contexts([model_version.proto])[0]
-    mv_id = str(mv_id)
-
-    ma1 = evolve(model.py)
-    model_registry.upsert_model_artifact(ma1, mv_id)
-    ma2 = evolve(model.py)
     with pytest.raises(StoreException):
-        model_registry.upsert_model_artifact(ma2, mv_id)
+        mr_client.register_model(**params)
 
 
-def test_get_model_artifact_by_id(model_registry: ModelRegistry, model: Mapped):
-    model.proto.name = f"test_prefix:{model.proto.name}"
-    id = model_registry._store._mlmd_store.put_artifacts([model.proto])[0]
-    id = str(id)
+def test_get(mr_client: ModelRegistry):
+    name = "test_model"
+    version = "1.0.0"
 
-    mlmd_ma = model_registry.get_model_artifact_by_id(id)
-
-    assert mlmd_ma.id == id
-    assert mlmd_ma.name == model.py.name
-    assert mlmd_ma.name != model.proto.name
-
-
-def test_get_model_artifact_by_model_version_id(
-    model_registry: ModelRegistry, model: Mapped, model_version: Mapped
-):
-    mv_id = model_registry._store._mlmd_store.put_contexts([model_version.proto])[0]
-
-    model.proto.name = f"test_prefix:{model.proto.name}"
-    ma_id = model_registry._store._mlmd_store.put_artifacts([model.proto])[0]
-
-    model_registry._store._mlmd_store.put_attributions_and_associations(
-        [Attribution(context_id=mv_id, artifact_id=ma_id)], []
+    rm = mr_client.register_model(
+        name,
+        "s3",
+        model_format_name="test_format",
+        model_format_version="test_version",
+        version=version,
     )
 
-    mlmd_ma = model_registry.get_model_artifact_by_params(model_version_id=str(mv_id))
+    assert rm.id == mr_client.get_registered_model(name).id
 
-    assert mlmd_ma.id == str(ma_id)
-    assert mlmd_ma.name == model.py.name
-    assert mlmd_ma.name != model.proto.name
+    mr_api = mr_client._api
+    mv = mr_api.get_model_version_by_params(rm.id, version)
+    ma = mr_api.get_model_artifact_by_params(mv.id)
 
-
-def test_get_model_artifact_by_external_id(
-    model_registry: ModelRegistry, model: Mapped
-):
-    model.proto.name = f"test_prefix:{model.proto.name}"
-    model.proto.external_id = "external_id"
-    model.py.external_id = "external_id"
-
-    id = model_registry._store._mlmd_store.put_artifacts([model.proto])[0]
-    id = str(id)
-
-    mlmd_ma = model_registry.get_model_artifact_by_params(
-        external_id=model.py.external_id
-    )
-
-    assert mlmd_ma.id == id
-    assert mlmd_ma.name == model.py.name
-    assert mlmd_ma.name != model.proto.name
-
-
-def test_get_all_model_artifacts(model_registry: ModelRegistry, model: Mapped):
-    model.proto.name = "test_prefix:model1"
-    ma1_id = model_registry._store._mlmd_store.put_artifacts([model.proto])[0]
-    model.proto.name = "test_prefix:model2"
-    ma2_id = model_registry._store._mlmd_store.put_artifacts([model.proto])[0]
-
-    mlmd_mas = model_registry.get_model_artifacts()
-    assert len(mlmd_mas) == 2
-    assert mlmd_mas[0].id in [str(ma1_id), str(ma2_id)]
-
-
-def test_get_model_artifacts_by_mv_id(
-    model_registry: ModelRegistry, model: Mapped, model_version: Mapped
-):
-    mv1_id = model_registry._store._mlmd_store.put_contexts([model_version.proto])[0]
-
-    model_version.proto.name = "version2"
-    mv2_id = model_registry._store._mlmd_store.put_contexts([model_version.proto])[0]
-
-    model.proto.name = "test_prefix:model1"
-    ma1_id = model_registry._store._mlmd_store.put_artifacts([model.proto])[0]
-    model.proto.name = "test_prefix:model2"
-    ma2_id = model_registry._store._mlmd_store.put_artifacts([model.proto])[0]
-
-    model_registry._store._mlmd_store.put_attributions_and_associations(
-        [
-            Attribution(context_id=mv1_id, artifact_id=ma1_id),
-            Attribution(context_id=mv2_id, artifact_id=ma2_id),
-        ],
-        [],
-    )
-
-    mlmd_mas = model_registry.get_model_artifacts(str(mv1_id))
-    assert len(mlmd_mas) == 1
-    assert mlmd_mas[0].id == str(ma1_id)
+    assert mv.id == mr_client.get_model_version(name, version).id
+    assert ma.id == mr_client.get_model_artifact(name, version).id

--- a/clients/python/tests/test_core.py
+++ b/clients/python/tests/test_core.py
@@ -1,0 +1,344 @@
+"""Tests for user facing model registry APIs."""
+
+import pytest
+from attrs import evolve
+from ml_metadata.proto import (
+    Artifact,
+    Attribution,
+    Context,
+    ParentContext,
+)
+from model_registry.core import ModelRegistryAPIClient
+from model_registry.exceptions import StoreException
+from model_registry.store import MLMDStore
+from model_registry.types import ModelArtifact, ModelVersion, RegisteredModel
+
+from . import Mapped
+
+
+@pytest.fixture()
+def model(store_wrapper: MLMDStore) -> Mapped:
+    art = Artifact()
+    # we can't test the name directly as it's prefixed
+    art.name = "model"
+    art.type_id = store_wrapper.get_type_id(
+        Artifact, ModelArtifact.get_proto_type_name()
+    )
+
+    art.uri = "uri"
+
+    return Mapped(art, ModelArtifact("model", "uri"))
+
+
+@pytest.fixture()
+def model_version(store_wrapper: MLMDStore, model: Mapped) -> Mapped:
+    ctx = Context()
+    # we can't test the name directly as it's prefixed
+    ctx.name = "version"
+    ctx.type_id = store_wrapper.get_type_id(Context, ModelVersion.get_proto_type_name())
+    ctx.properties["author"].string_value = "author"
+    ctx.properties["model_name"].string_value = model.py.name
+
+    return Mapped(ctx, ModelVersion(model.py.name, "version", "author"))
+
+
+@pytest.fixture()
+def registered_model(store_wrapper: MLMDStore, model: Mapped) -> Mapped:
+    ctx = Context()
+    ctx.name = model.py.name
+    ctx.type_id = store_wrapper.get_type_id(
+        Context, RegisteredModel.get_proto_type_name()
+    )
+
+    return Mapped(ctx, RegisteredModel(model.py.name))
+
+
+# TODO: should we test insert/update separately?
+def test_upsert_registered_model(
+    mr_api: ModelRegistryAPIClient, registered_model: Mapped
+):
+    mr_api.upsert_registered_model(registered_model.py)
+
+    rm_proto = mr_api._store._mlmd_store.get_context_by_type_and_name(
+        RegisteredModel.get_proto_type_name(), registered_model.proto.name
+    )
+    assert rm_proto is not None
+    assert registered_model.py.id == str(rm_proto.id)
+    assert registered_model.py.name == rm_proto.name
+
+
+def test_get_registered_model_by_id(
+    mr_api: ModelRegistryAPIClient,
+    registered_model: Mapped,
+):
+    rm_id = mr_api._store._mlmd_store.put_contexts([registered_model.proto])[0]
+
+    mlmd_rm = mr_api.get_registered_model_by_id(str(rm_id))
+    assert mlmd_rm.id == str(rm_id)
+    assert mlmd_rm.name == registered_model.py.name
+    assert mlmd_rm.name == registered_model.proto.name
+
+
+def test_get_registered_model_by_name(
+    mr_api: ModelRegistryAPIClient,
+    registered_model: Mapped,
+):
+    rm_id = mr_api._store._mlmd_store.put_contexts([registered_model.proto])[0]
+
+    mlmd_rm = mr_api.get_registered_model_by_params(name=registered_model.py.name)
+    assert mlmd_rm.id == str(rm_id)
+    assert mlmd_rm.name == registered_model.py.name
+    assert mlmd_rm.name == registered_model.proto.name
+
+
+def test_get_registered_model_by_external_id(
+    mr_api: ModelRegistryAPIClient,
+    registered_model: Mapped,
+):
+    registered_model.py.external_id = "external_id"
+    registered_model.proto.external_id = "external_id"
+    rm_id = mr_api._store._mlmd_store.put_contexts([registered_model.proto])[0]
+
+    mlmd_rm = mr_api.get_registered_model_by_params(
+        external_id=registered_model.py.external_id
+    )
+    assert mlmd_rm.id == str(rm_id)
+    assert mlmd_rm.name == registered_model.py.name
+    assert mlmd_rm.name == registered_model.proto.name
+
+
+def test_get_registered_models(
+    mr_api: ModelRegistryAPIClient, registered_model: Mapped
+):
+    rm1_id = mr_api._store._mlmd_store.put_contexts([registered_model.proto])[0]
+    registered_model.proto.name = "model2"
+    rm2_id = mr_api._store._mlmd_store.put_contexts([registered_model.proto])[0]
+
+    mlmd_rms = mr_api.get_registered_models()
+    assert len(mlmd_rms) == 2
+    assert mlmd_rms[0].id in [str(rm1_id), str(rm2_id)]
+
+
+def test_upsert_model_version(
+    mr_api: ModelRegistryAPIClient,
+    model_version: Mapped,
+    registered_model: Mapped,
+):
+    rm_id = mr_api._store._mlmd_store.put_contexts([registered_model.proto])[0]
+    rm_id = str(rm_id)
+
+    mr_api.upsert_model_version(model_version.py, rm_id)
+
+    mv_proto = mr_api._store._mlmd_store.get_context_by_type_and_name(
+        ModelVersion.get_proto_type_name(), f"{rm_id}:{model_version.proto.name}"
+    )
+    assert mv_proto is not None
+    assert model_version.py.id == str(mv_proto.id)
+    assert model_version.py.version != mv_proto.name
+
+
+def test_get_model_version_by_id(mr_api: ModelRegistryAPIClient, model_version: Mapped):
+    model_version.proto.name = f"1:{model_version.proto.name}"
+    ctx_id = mr_api._store._mlmd_store.put_contexts([model_version.proto])[0]
+
+    id = str(ctx_id)
+    mlmd_mv = mr_api.get_model_version_by_id(id)
+    assert mlmd_mv.id == id
+    assert mlmd_mv.name == model_version.py.name
+    assert mlmd_mv.version != model_version.proto.name
+
+
+def test_get_model_version_by_name(
+    mr_api: ModelRegistryAPIClient, model_version: Mapped
+):
+    model_version.proto.name = f"1:{model_version.proto.name}"
+    mv_id = mr_api._store._mlmd_store.put_contexts([model_version.proto])[0]
+
+    mlmd_mv = mr_api.get_model_version_by_params(
+        registered_model_id="1", version=model_version.py.name
+    )
+    assert mlmd_mv.id == str(mv_id)
+    assert mlmd_mv.name == model_version.py.name
+    assert mlmd_mv.name != model_version.proto.name
+
+
+def test_get_model_version_by_external_id(
+    mr_api: ModelRegistryAPIClient, model_version: Mapped
+):
+    model_version.proto.name = f"1:{model_version.proto.name}"
+    model_version.proto.external_id = "external_id"
+    model_version.py.external_id = "external_id"
+    mv_id = mr_api._store._mlmd_store.put_contexts([model_version.proto])[0]
+
+    mlmd_mv = mr_api.get_model_version_by_params(
+        external_id=model_version.py.external_id
+    )
+    assert mlmd_mv.id == str(mv_id)
+    assert mlmd_mv.name == model_version.py.name
+    assert mlmd_mv.name != model_version.proto.name
+
+
+def test_get_model_versions(
+    mr_api: ModelRegistryAPIClient,
+    model_version: Mapped,
+    registered_model: Mapped,
+):
+    rm_id = mr_api._store._mlmd_store.put_contexts([registered_model.proto])[0]
+
+    model_version.proto.name = f"{rm_id}:version"
+    mv1_id = mr_api._store._mlmd_store.put_contexts([model_version.proto])[0]
+    model_version.proto.name = f"{rm_id}:version2"
+    mv2_id = mr_api._store._mlmd_store.put_contexts([model_version.proto])[0]
+
+    mr_api._store._mlmd_store.put_parent_contexts(
+        [
+            ParentContext(parent_id=rm_id, child_id=mv1_id),
+            ParentContext(parent_id=rm_id, child_id=mv2_id),
+        ]
+    )
+
+    mlmd_mvs = mr_api.get_model_versions(str(rm_id))
+    assert len(mlmd_mvs) == 2
+    assert mlmd_mvs[0].id in [str(mv1_id), str(mv2_id)]
+
+
+def test_upsert_model_artifact(
+    monkeypatch,
+    mr_api: ModelRegistryAPIClient,
+    model: Mapped,
+    model_version: Mapped,
+):
+    monkeypatch.setattr(ModelArtifact, "mlmd_name_prefix", "test_prefix")
+
+    mv_id = mr_api._store._mlmd_store.put_contexts([model_version.proto])[0]
+    mv_id = str(mv_id)
+
+    mr_api.upsert_model_artifact(model.py, mv_id)
+
+    ma_proto = mr_api._store._mlmd_store.get_artifact_by_type_and_name(
+        ModelArtifact.get_proto_type_name(), f"test_prefix:{model.proto.name}"
+    )
+    assert ma_proto is not None
+    assert model.py.id == str(ma_proto.id)
+    assert model.py.name != ma_proto.name
+
+
+def test_upsert_duplicate_model_artifact_with_different_version(
+    mr_api: ModelRegistryAPIClient, model: Mapped, model_version: Mapped
+):
+    mv1_id = mr_api._store._mlmd_store.put_contexts([model_version.proto])[0]
+    mv1_id = str(mv1_id)
+
+    model_version.proto.name = "version2"
+    mv2_id = mr_api._store._mlmd_store.put_contexts([model_version.proto])[0]
+    mv2_id = str(mv2_id)
+
+    ma1 = evolve(model.py)
+    mr_api.upsert_model_artifact(ma1, mv1_id)
+    ma2 = evolve(model.py)
+    mr_api.upsert_model_artifact(ma2, mv2_id)
+
+    ma_protos = mr_api._store._mlmd_store.get_artifacts_by_id(
+        [int(ma1.id), int(ma2.id)]
+    )
+    assert ma1.name == ma2.name
+    assert ma1.name != str(ma_protos[0].name)
+    assert ma2.name != str(ma_protos[1].name)
+
+
+def test_upsert_duplicate_model_artifact_with_same_version(
+    mr_api: ModelRegistryAPIClient, model: Mapped, model_version: Mapped
+):
+    mv_id = mr_api._store._mlmd_store.put_contexts([model_version.proto])[0]
+    mv_id = str(mv_id)
+
+    ma1 = evolve(model.py)
+    mr_api.upsert_model_artifact(ma1, mv_id)
+    ma2 = evolve(model.py)
+    with pytest.raises(StoreException):
+        mr_api.upsert_model_artifact(ma2, mv_id)
+
+
+def test_get_model_artifact_by_id(mr_api: ModelRegistryAPIClient, model: Mapped):
+    model.proto.name = f"test_prefix:{model.proto.name}"
+    id = mr_api._store._mlmd_store.put_artifacts([model.proto])[0]
+    id = str(id)
+
+    mlmd_ma = mr_api.get_model_artifact_by_id(id)
+
+    assert mlmd_ma.id == id
+    assert mlmd_ma.name == model.py.name
+    assert mlmd_ma.name != model.proto.name
+
+
+def test_get_model_artifact_by_model_version_id(
+    mr_api: ModelRegistryAPIClient, model: Mapped, model_version: Mapped
+):
+    mv_id = mr_api._store._mlmd_store.put_contexts([model_version.proto])[0]
+
+    model.proto.name = f"test_prefix:{model.proto.name}"
+    ma_id = mr_api._store._mlmd_store.put_artifacts([model.proto])[0]
+
+    mr_api._store._mlmd_store.put_attributions_and_associations(
+        [Attribution(context_id=mv_id, artifact_id=ma_id)], []
+    )
+
+    mlmd_ma = mr_api.get_model_artifact_by_params(model_version_id=str(mv_id))
+
+    assert mlmd_ma.id == str(ma_id)
+    assert mlmd_ma.name == model.py.name
+    assert mlmd_ma.name != model.proto.name
+
+
+def test_get_model_artifact_by_external_id(
+    mr_api: ModelRegistryAPIClient, model: Mapped
+):
+    model.proto.name = f"test_prefix:{model.proto.name}"
+    model.proto.external_id = "external_id"
+    model.py.external_id = "external_id"
+
+    id = mr_api._store._mlmd_store.put_artifacts([model.proto])[0]
+    id = str(id)
+
+    mlmd_ma = mr_api.get_model_artifact_by_params(external_id=model.py.external_id)
+
+    assert mlmd_ma.id == id
+    assert mlmd_ma.name == model.py.name
+    assert mlmd_ma.name != model.proto.name
+
+
+def test_get_all_model_artifacts(mr_api: ModelRegistryAPIClient, model: Mapped):
+    model.proto.name = "test_prefix:model1"
+    ma1_id = mr_api._store._mlmd_store.put_artifacts([model.proto])[0]
+    model.proto.name = "test_prefix:model2"
+    ma2_id = mr_api._store._mlmd_store.put_artifacts([model.proto])[0]
+
+    mlmd_mas = mr_api.get_model_artifacts()
+    assert len(mlmd_mas) == 2
+    assert mlmd_mas[0].id in [str(ma1_id), str(ma2_id)]
+
+
+def test_get_model_artifacts_by_mv_id(
+    mr_api: ModelRegistryAPIClient, model: Mapped, model_version: Mapped
+):
+    mv1_id = mr_api._store._mlmd_store.put_contexts([model_version.proto])[0]
+
+    model_version.proto.name = "version2"
+    mv2_id = mr_api._store._mlmd_store.put_contexts([model_version.proto])[0]
+
+    model.proto.name = "test_prefix:model1"
+    ma1_id = mr_api._store._mlmd_store.put_artifacts([model.proto])[0]
+    model.proto.name = "test_prefix:model2"
+    ma2_id = mr_api._store._mlmd_store.put_artifacts([model.proto])[0]
+
+    mr_api._store._mlmd_store.put_attributions_and_associations(
+        [
+            Attribution(context_id=mv1_id, artifact_id=ma1_id),
+            Attribution(context_id=mv2_id, artifact_id=ma2_id),
+        ],
+        [],
+    )
+
+    mlmd_mas = mr_api.get_model_artifacts(str(mv1_id))
+    assert len(mlmd_mas) == 1
+    assert mlmd_mas[0].id == str(ma1_id)


### PR DESCRIPTION
## Description

Introduce the first iteration of a higher-level Python API as proposed on #129.

Related: #129
Depends on: #209

## How Has This Been Tested?

New tests were introduced on `tests/test_client.py`.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
