### PR TITLE
Improve core testing using single test container

### DIFF
--- a/pkg/core/core_test.go
+++ b/pkg/core/core_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/opendatahub-io/model-registry/internal/testutils"
 	"github.com/opendatahub-io/model-registry/pkg/api"
 	"github.com/opendatahub-io/model-registry/pkg/openapi"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 )
 
@@ -45,12 +45,26 @@ var (
 	executionState string
 )
 
-func setup(t *testing.T) (*assert.Assertions, *grpc.ClientConn, proto.MetadataStoreServiceClient, func(t *testing.T)) {
-	if testing.Short() {
-		// skip these tests using -short param
-		t.Skip("skipping testing in short mode")
-	}
+type CoreTestSuite struct {
+	suite.Suite
+	grpcConn   *grpc.ClientConn
+	mlmdClient proto.MetadataStoreServiceClient
+}
 
+func TestRunCoreTestSuite(t *testing.T) {
+	// before all
+	grpcConn, mlmdClient, teardown := testutils.SetupMLMetadataTestContainer(t)
+	defer teardown(t)
+
+	coreTestSuite := CoreTestSuite{
+		grpcConn:   grpcConn,
+		mlmdClient: mlmdClient,
+	}
+	suite.Run(t, &coreTestSuite)
+}
+
+// befor each test case
+func (suite *CoreTestSuite) SetupTest() {
 	// initialize test variable before each test
 	ascOrderDirection = "ASC"
 	descOrderDirection = "DESC"
@@ -73,20 +87,27 @@ func setup(t *testing.T) (*assert.Assertions, *grpc.ClientConn, proto.MetadataSt
 	entityExternalId2 = "entityExternalID2"
 	entityDescription = "lorem ipsum entity description"
 	executionState = "RUNNING"
-
-	conn, client, teardown := testutils.SetupMLMDTestContainer(t)
-	return assert.New(t), conn, client, teardown
 }
 
-// initialize model registry service and assert no error is thrown
-func initModelRegistryService(assertion *assert.Assertions, conn *grpc.ClientConn) api.ModelRegistryApi {
-	service, err := NewModelRegistryService(conn)
-	assertion.Nilf(err, "error creating core service: %v", err)
-	return service
+// after each test
+//   - remove the metadata sqlite file used by mlmd, this way mlmd will recreate it
+func (suite *CoreTestSuite) AfterTest(suiteName, testName string) {
+	if err := testutils.ClearMetadataSqliteDB(); err != nil {
+		suite.Error(err)
+	}
+}
+
+func (suite *CoreTestSuite) setupModelRegistryService() *ModelRegistryService {
+	// setup model registry service
+	service, err := NewModelRegistryService(suite.grpcConn)
+	suite.Nilf(err, "error creating core service: %v", err)
+	mrService, ok := service.(*ModelRegistryService)
+	suite.True(ok)
+	return mrService
 }
 
 // utility function that register a new simple model and return its ID
-func registerModel(assertion *assert.Assertions, service api.ModelRegistryApi, overrideModelName *string, overrideExternalId *string) string {
+func (suite *CoreTestSuite) registerModel(service api.ModelRegistryApi, overrideModelName *string, overrideExternalId *string) string {
 	registeredModel := &openapi.RegisteredModel{
 		Name:        &modelName,
 		ExternalID:  &modelExternalId,
@@ -110,13 +131,13 @@ func registerModel(assertion *assert.Assertions, service api.ModelRegistryApi, o
 
 	// test
 	createdModel, err := service.UpsertRegisteredModel(registeredModel)
-	assertion.Nilf(err, "error creating registered model: %v", err)
+	suite.Nilf(err, "error creating registered model: %v", err)
 
 	return *createdModel.Id
 }
 
 // utility function that register a new simple ServingEnvironment and return its ID
-func registerServingEnvironment(assertion *assert.Assertions, service api.ModelRegistryApi, overrideName *string, overrideExternalId *string) string {
+func (suite *CoreTestSuite) registerServingEnvironment(service api.ModelRegistryApi, overrideName *string, overrideExternalId *string) string {
 	eutName := "Simple ServingEnvironment"
 	eutExtID := "Simple ServingEnvironment ExtID"
 	eut := &openapi.ServingEnvironment{
@@ -142,21 +163,20 @@ func registerServingEnvironment(assertion *assert.Assertions, service api.ModelR
 
 	// test
 	createdEntity, err := service.UpsertServingEnvironment(eut)
-	assertion.Nilf(err, "error creating ServingEnvironment: %v", err)
+	suite.Nilf(err, "error creating ServingEnvironment: %v", err)
 
 	return *createdEntity.Id
 }
 
 // utility function that register a new simple model and return its ID
-func registerModelVersion(
-	assertion *assert.Assertions,
+func (suite *CoreTestSuite) registerModelVersion(
 	service api.ModelRegistryApi,
 	overrideModelName *string,
 	overrideExternalId *string,
 	overrideVersionName *string,
 	overrideVersionExtId *string,
 ) string {
-	registeredModelId := registerModel(assertion, service, overrideModelName, overrideExternalId)
+	registeredModelId := suite.registerModel(service, overrideModelName, overrideExternalId)
 
 	modelVersion := &openapi.ModelVersion{
 		Name:        &modelVersionName,
@@ -174,14 +194,14 @@ func registerModelVersion(
 	}
 
 	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
-	assertion.Nilf(err, "error creating model version: %v", err)
+	suite.Nilf(err, "error creating model version: %v", err)
 
 	return *createdVersion.Id
 }
 
 // utility function that register a new simple ServingEnvironment and return its ID
-func registerInferenceService(assertion *assert.Assertions, service api.ModelRegistryApi, registerdModelId string, overrideParentResourceName *string, overrideParentResourceExternalId *string, overrideName *string, overrideExternalId *string) string {
-	servingEnvironmentId := registerServingEnvironment(assertion, service, overrideParentResourceName, overrideParentResourceExternalId)
+func (suite *CoreTestSuite) registerInferenceService(service api.ModelRegistryApi, registerdModelId string, overrideParentResourceName *string, overrideParentResourceExternalId *string, overrideName *string, overrideExternalId *string) string {
+	servingEnvironmentId := suite.registerServingEnvironment(service, overrideParentResourceName, overrideParentResourceExternalId)
 
 	eutName := "simpleInferenceService"
 	eutExtID := "simpleInferenceService ExtID"
@@ -208,15 +228,13 @@ func registerInferenceService(assertion *assert.Assertions, service api.ModelReg
 
 	// test
 	createdEntity, err := service.UpsertInferenceService(eut)
-	assertion.Nilf(err, "error creating InferenceService: %v", err)
+	suite.Nilf(err, "error creating InferenceService: %v", err)
 
 	return *createdEntity.Id
 }
 
-func TestModelRegistryStartupWithExistingEmptyTypes(t *testing.T) {
+func (suite *CoreTestSuite) TestModelRegistryStartupWithExistingEmptyTypes() {
 	ctx := context.Background()
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
 
 	// create all types without props
 	registeredModelReq := proto.PutContextTypeRequest{
@@ -256,145 +274,139 @@ func TestModelRegistryStartupWithExistingEmptyTypes(t *testing.T) {
 		},
 	}
 
-	_, err := client.PutContextType(context.Background(), &registeredModelReq)
-	assertion.Nil(err)
-	_, err = client.PutContextType(context.Background(), &modelVersionReq)
-	assertion.Nil(err)
-	_, err = client.PutArtifactType(context.Background(), &modelArtifactReq)
-	assertion.Nil(err)
-	_, err = client.PutContextType(context.Background(), &servingEnvironmentReq)
-	assertion.Nil(err)
-	_, err = client.PutContextType(context.Background(), &inferenceServiceReq)
-	assertion.Nil(err)
-	_, err = client.PutExecutionType(context.Background(), &serveModelReq)
-	assertion.Nil(err)
+	_, err := suite.mlmdClient.PutContextType(context.Background(), &registeredModelReq)
+	suite.Nil(err)
+	_, err = suite.mlmdClient.PutContextType(context.Background(), &modelVersionReq)
+	suite.Nil(err)
+	_, err = suite.mlmdClient.PutArtifactType(context.Background(), &modelArtifactReq)
+	suite.Nil(err)
+	_, err = suite.mlmdClient.PutContextType(context.Background(), &servingEnvironmentReq)
+	suite.Nil(err)
+	_, err = suite.mlmdClient.PutContextType(context.Background(), &inferenceServiceReq)
+	suite.Nil(err)
+	_, err = suite.mlmdClient.PutExecutionType(context.Background(), &serveModelReq)
+	suite.Nil(err)
 
 	// check empty props
-	regModelResp, _ := client.GetContextType(ctx, &proto.GetContextTypeRequest{
+	regModelResp, _ := suite.mlmdClient.GetContextType(ctx, &proto.GetContextTypeRequest{
 		TypeName: registeredModelTypeName,
 	})
-	modelVersionResp, _ := client.GetContextType(ctx, &proto.GetContextTypeRequest{
+	modelVersionResp, _ := suite.mlmdClient.GetContextType(ctx, &proto.GetContextTypeRequest{
 		TypeName: modelVersionTypeName,
 	})
-	modelArtifactResp, _ := client.GetArtifactType(ctx, &proto.GetArtifactTypeRequest{
+	modelArtifactResp, _ := suite.mlmdClient.GetArtifactType(ctx, &proto.GetArtifactTypeRequest{
 		TypeName: modelArtifactTypeName,
 	})
-	servingEnvResp, _ := client.GetContextType(ctx, &proto.GetContextTypeRequest{
+	servingEnvResp, _ := suite.mlmdClient.GetContextType(ctx, &proto.GetContextTypeRequest{
 		TypeName: servingEnvironmentTypeName,
 	})
-	inferenceServiceResp, _ := client.GetContextType(ctx, &proto.GetContextTypeRequest{
+	inferenceServiceResp, _ := suite.mlmdClient.GetContextType(ctx, &proto.GetContextTypeRequest{
 		TypeName: inferenceServiceTypeName,
 	})
-	serveModelResp, _ := client.GetExecutionType(ctx, &proto.GetExecutionTypeRequest{
+	serveModelResp, _ := suite.mlmdClient.GetExecutionType(ctx, &proto.GetExecutionTypeRequest{
 		TypeName: serveModelTypeName,
 	})
 
-	assertion.Equal(0, len(regModelResp.ContextType.Properties))
-	assertion.Equal(0, len(modelVersionResp.ContextType.Properties))
-	assertion.Equal(0, len(modelArtifactResp.ArtifactType.Properties))
-	assertion.Equal(0, len(servingEnvResp.ContextType.Properties))
-	assertion.Equal(0, len(inferenceServiceResp.ContextType.Properties))
-	assertion.Equal(0, len(serveModelResp.ExecutionType.Properties))
+	suite.Equal(0, len(regModelResp.ContextType.Properties))
+	suite.Equal(0, len(modelVersionResp.ContextType.Properties))
+	suite.Equal(0, len(modelArtifactResp.ArtifactType.Properties))
+	suite.Equal(0, len(servingEnvResp.ContextType.Properties))
+	suite.Equal(0, len(inferenceServiceResp.ContextType.Properties))
+	suite.Equal(0, len(serveModelResp.ExecutionType.Properties))
 
 	// create model registry service
-	_, err = NewModelRegistryService(conn)
-	assertion.Nil(err)
+	_, err = NewModelRegistryService(suite.grpcConn)
+	suite.Nil(err)
 
 	// assure the types have been correctly setup at startup
 	// check NOT empty props
-	regModelResp, _ = client.GetContextType(ctx, &proto.GetContextTypeRequest{
+	regModelResp, _ = suite.mlmdClient.GetContextType(ctx, &proto.GetContextTypeRequest{
 		TypeName: registeredModelTypeName,
 	})
-	assertion.NotNilf(regModelResp.ContextType, "registered model type %s should exists", *registeredModelTypeName)
-	assertion.Equal(*registeredModelTypeName, *regModelResp.ContextType.Name)
-	assertion.Equal(2, len(regModelResp.ContextType.Properties))
+	suite.NotNilf(regModelResp.ContextType, "registered model type %s should exists", *registeredModelTypeName)
+	suite.Equal(*registeredModelTypeName, *regModelResp.ContextType.Name)
+	suite.Equal(2, len(regModelResp.ContextType.Properties))
 
-	modelVersionResp, _ = client.GetContextType(ctx, &proto.GetContextTypeRequest{
+	modelVersionResp, _ = suite.mlmdClient.GetContextType(ctx, &proto.GetContextTypeRequest{
 		TypeName: modelVersionTypeName,
 	})
-	assertion.NotNilf(modelVersionResp.ContextType, "model version type %s should exists", *modelVersionTypeName)
-	assertion.Equal(*modelVersionTypeName, *modelVersionResp.ContextType.Name)
-	assertion.Equal(5, len(modelVersionResp.ContextType.Properties))
+	suite.NotNilf(modelVersionResp.ContextType, "model version type %s should exists", *modelVersionTypeName)
+	suite.Equal(*modelVersionTypeName, *modelVersionResp.ContextType.Name)
+	suite.Equal(5, len(modelVersionResp.ContextType.Properties))
 
-	modelArtifactResp, _ = client.GetArtifactType(ctx, &proto.GetArtifactTypeRequest{
+	modelArtifactResp, _ = suite.mlmdClient.GetArtifactType(ctx, &proto.GetArtifactTypeRequest{
 		TypeName: modelArtifactTypeName,
 	})
-	assertion.NotNilf(modelArtifactResp.ArtifactType, "model artifact type %s should exists", *modelArtifactTypeName)
-	assertion.Equal(*modelArtifactTypeName, *modelArtifactResp.ArtifactType.Name)
-	assertion.Equal(6, len(modelArtifactResp.ArtifactType.Properties))
+	suite.NotNilf(modelArtifactResp.ArtifactType, "model artifact type %s should exists", *modelArtifactTypeName)
+	suite.Equal(*modelArtifactTypeName, *modelArtifactResp.ArtifactType.Name)
+	suite.Equal(6, len(modelArtifactResp.ArtifactType.Properties))
 
-	servingEnvResp, _ = client.GetContextType(ctx, &proto.GetContextTypeRequest{
+	servingEnvResp, _ = suite.mlmdClient.GetContextType(ctx, &proto.GetContextTypeRequest{
 		TypeName: servingEnvironmentTypeName,
 	})
-	assertion.NotNilf(servingEnvResp.ContextType, "serving environment type %s should exists", *servingEnvironmentTypeName)
-	assertion.Equal(*servingEnvironmentTypeName, *servingEnvResp.ContextType.Name)
-	assertion.Equal(1, len(servingEnvResp.ContextType.Properties))
+	suite.NotNilf(servingEnvResp.ContextType, "serving environment type %s should exists", *servingEnvironmentTypeName)
+	suite.Equal(*servingEnvironmentTypeName, *servingEnvResp.ContextType.Name)
+	suite.Equal(1, len(servingEnvResp.ContextType.Properties))
 
-	inferenceServiceResp, _ = client.GetContextType(ctx, &proto.GetContextTypeRequest{
+	inferenceServiceResp, _ = suite.mlmdClient.GetContextType(ctx, &proto.GetContextTypeRequest{
 		TypeName: inferenceServiceTypeName,
 	})
-	assertion.NotNilf(inferenceServiceResp.ContextType, "inference service type %s should exists", *inferenceServiceTypeName)
-	assertion.Equal(*inferenceServiceTypeName, *inferenceServiceResp.ContextType.Name)
-	assertion.Equal(6, len(inferenceServiceResp.ContextType.Properties))
+	suite.NotNilf(inferenceServiceResp.ContextType, "inference service type %s should exists", *inferenceServiceTypeName)
+	suite.Equal(*inferenceServiceTypeName, *inferenceServiceResp.ContextType.Name)
+	suite.Equal(6, len(inferenceServiceResp.ContextType.Properties))
 
-	serveModelResp, _ = client.GetExecutionType(ctx, &proto.GetExecutionTypeRequest{
+	serveModelResp, _ = suite.mlmdClient.GetExecutionType(ctx, &proto.GetExecutionTypeRequest{
 		TypeName: serveModelTypeName,
 	})
-	assertion.NotNilf(serveModelResp.ExecutionType, "serve model type %s should exists", *serveModelTypeName)
-	assertion.Equal(*serveModelTypeName, *serveModelResp.ExecutionType.Name)
-	assertion.Equal(2, len(serveModelResp.ExecutionType.Properties))
+	suite.NotNilf(serveModelResp.ExecutionType, "serve model type %s should exists", *serveModelTypeName)
+	suite.Equal(*serveModelTypeName, *serveModelResp.ExecutionType.Name)
+	suite.Equal(2, len(serveModelResp.ExecutionType.Properties))
 }
 
-func TestModelRegistryTypes(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestModelRegistryTypes() {
 	// create model registry service
-	_ = initModelRegistryService(assertion, conn)
+	_ = suite.setupModelRegistryService()
 
 	// assure the types have been correctly setup at startup
 	ctx := context.Background()
-	regModelResp, _ := client.GetContextType(ctx, &proto.GetContextTypeRequest{
+	regModelResp, _ := suite.mlmdClient.GetContextType(ctx, &proto.GetContextTypeRequest{
 		TypeName: registeredModelTypeName,
 	})
-	assertion.NotNilf(regModelResp.ContextType, "registered model type %s should exists", *registeredModelTypeName)
-	assertion.Equal(*registeredModelTypeName, *regModelResp.ContextType.Name)
+	suite.NotNilf(regModelResp.ContextType, "registered model type %s should exists", *registeredModelTypeName)
+	suite.Equal(*registeredModelTypeName, *regModelResp.ContextType.Name)
 
-	modelVersionResp, _ := client.GetContextType(ctx, &proto.GetContextTypeRequest{
+	modelVersionResp, _ := suite.mlmdClient.GetContextType(ctx, &proto.GetContextTypeRequest{
 		TypeName: modelVersionTypeName,
 	})
-	assertion.NotNilf(modelVersionResp.ContextType, "model version type %s should exists", *modelVersionTypeName)
-	assertion.Equal(*modelVersionTypeName, *modelVersionResp.ContextType.Name)
+	suite.NotNilf(modelVersionResp.ContextType, "model version type %s should exists", *modelVersionTypeName)
+	suite.Equal(*modelVersionTypeName, *modelVersionResp.ContextType.Name)
 
-	modelArtifactResp, _ := client.GetArtifactType(ctx, &proto.GetArtifactTypeRequest{
+	modelArtifactResp, _ := suite.mlmdClient.GetArtifactType(ctx, &proto.GetArtifactTypeRequest{
 		TypeName: modelArtifactTypeName,
 	})
-	assertion.NotNilf(modelArtifactResp.ArtifactType, "model version type %s should exists", *modelArtifactTypeName)
-	assertion.Equal(*modelArtifactTypeName, *modelArtifactResp.ArtifactType.Name)
+	suite.NotNilf(modelArtifactResp.ArtifactType, "model version type %s should exists", *modelArtifactTypeName)
+	suite.Equal(*modelArtifactTypeName, *modelArtifactResp.ArtifactType.Name)
 
-	servingEnvResp, _ := client.GetContextType(ctx, &proto.GetContextTypeRequest{
+	servingEnvResp, _ := suite.mlmdClient.GetContextType(ctx, &proto.GetContextTypeRequest{
 		TypeName: servingEnvironmentTypeName,
 	})
-	assertion.NotNilf(servingEnvResp.ContextType, "serving environment type %s should exists", *servingEnvironmentTypeName)
-	assertion.Equal(*servingEnvironmentTypeName, *servingEnvResp.ContextType.Name)
+	suite.NotNilf(servingEnvResp.ContextType, "serving environment type %s should exists", *servingEnvironmentTypeName)
+	suite.Equal(*servingEnvironmentTypeName, *servingEnvResp.ContextType.Name)
 
-	inferenceServiceResp, _ := client.GetContextType(ctx, &proto.GetContextTypeRequest{
+	inferenceServiceResp, _ := suite.mlmdClient.GetContextType(ctx, &proto.GetContextTypeRequest{
 		TypeName: inferenceServiceTypeName,
 	})
-	assertion.NotNilf(inferenceServiceResp.ContextType, "inference service type %s should exists", *inferenceServiceTypeName)
-	assertion.Equal(*inferenceServiceTypeName, *inferenceServiceResp.ContextType.Name)
+	suite.NotNilf(inferenceServiceResp.ContextType, "inference service type %s should exists", *inferenceServiceTypeName)
+	suite.Equal(*inferenceServiceTypeName, *inferenceServiceResp.ContextType.Name)
 
-	serveModelResp, _ := client.GetExecutionType(ctx, &proto.GetExecutionTypeRequest{
+	serveModelResp, _ := suite.mlmdClient.GetExecutionType(ctx, &proto.GetExecutionTypeRequest{
 		TypeName: serveModelTypeName,
 	})
-	assertion.NotNilf(serveModelResp.ExecutionType, "serve model type %s should exists", *serveModelTypeName)
-	assertion.Equal(*serveModelTypeName, *serveModelResp.ExecutionType.Name)
+	suite.NotNilf(serveModelResp.ExecutionType, "serve model type %s should exists", *serveModelTypeName)
+	suite.Equal(*serveModelTypeName, *serveModelResp.ExecutionType.Name)
 }
 
-func TestModelRegistryFailureForOmittedFieldInRegisteredModel(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestModelRegistryFailureForOmittedFieldInRegisteredModel() {
 	registeredModelReq := proto.PutContextTypeRequest{
 		CanAddFields: canAddFields,
 		ContextType: &proto.ContextType{
@@ -405,19 +417,16 @@ func TestModelRegistryFailureForOmittedFieldInRegisteredModel(t *testing.T) {
 		},
 	}
 
-	_, err := client.PutContextType(context.Background(), &registeredModelReq)
-	assertion.Nil(err)
+	_, err := suite.mlmdClient.PutContextType(context.Background(), &registeredModelReq)
+	suite.Nil(err)
 
 	// create model registry service
-	_, err = NewModelRegistryService(conn)
-	assertion.NotNil(err)
-	assertion.Regexp("error setting up context type odh.RegisteredModel: rpc error: code = AlreadyExists.*", err.Error())
+	_, err = NewModelRegistryService(suite.grpcConn)
+	suite.NotNil(err)
+	suite.Regexp("error setting up context type odh.RegisteredModel: rpc error: code = AlreadyExists.*", err.Error())
 }
 
-func TestModelRegistryFailureForOmittedFieldInModelVersion(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestModelRegistryFailureForOmittedFieldInModelVersion() {
 	modelVersionReq := proto.PutContextTypeRequest{
 		CanAddFields: canAddFields,
 		ContextType: &proto.ContextType{
@@ -428,19 +437,16 @@ func TestModelRegistryFailureForOmittedFieldInModelVersion(t *testing.T) {
 		},
 	}
 
-	_, err := client.PutContextType(context.Background(), &modelVersionReq)
-	assertion.Nil(err)
+	_, err := suite.mlmdClient.PutContextType(context.Background(), &modelVersionReq)
+	suite.Nil(err)
 
 	// create model registry service
-	_, err = NewModelRegistryService(conn)
-	assertion.NotNil(err)
-	assertion.Regexp("error setting up context type odh.ModelVersion: rpc error: code = AlreadyExists.*", err.Error())
+	_, err = NewModelRegistryService(suite.grpcConn)
+	suite.NotNil(err)
+	suite.Regexp("error setting up context type odh.ModelVersion: rpc error: code = AlreadyExists.*", err.Error())
 }
 
-func TestModelRegistryFailureForOmittedFieldInModelArtifact(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestModelRegistryFailureForOmittedFieldInModelArtifact() {
 	modelArtifactReq := proto.PutArtifactTypeRequest{
 		CanAddFields: canAddFields,
 		ArtifactType: &proto.ArtifactType{
@@ -451,19 +457,16 @@ func TestModelRegistryFailureForOmittedFieldInModelArtifact(t *testing.T) {
 		},
 	}
 
-	_, err := client.PutArtifactType(context.Background(), &modelArtifactReq)
-	assertion.Nil(err)
+	_, err := suite.mlmdClient.PutArtifactType(context.Background(), &modelArtifactReq)
+	suite.Nil(err)
 
 	// create model registry service
-	_, err = NewModelRegistryService(conn)
-	assertion.NotNil(err)
-	assertion.Regexp("error setting up artifact type odh.ModelArtifact: rpc error: code = AlreadyExists.*", err.Error())
+	_, err = NewModelRegistryService(suite.grpcConn)
+	suite.NotNil(err)
+	suite.Regexp("error setting up artifact type odh.ModelArtifact: rpc error: code = AlreadyExists.*", err.Error())
 }
 
-func TestModelRegistryFailureForOmittedFieldInServingEnvironment(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestModelRegistryFailureForOmittedFieldInServingEnvironment() {
 	servingEnvironmentReq := proto.PutContextTypeRequest{
 		CanAddFields: canAddFields,
 		ContextType: &proto.ContextType{
@@ -473,19 +476,16 @@ func TestModelRegistryFailureForOmittedFieldInServingEnvironment(t *testing.T) {
 			},
 		},
 	}
-	_, err := client.PutContextType(context.Background(), &servingEnvironmentReq)
-	assertion.Nil(err)
+	_, err := suite.mlmdClient.PutContextType(context.Background(), &servingEnvironmentReq)
+	suite.Nil(err)
 
 	// create model registry service
-	_, err = NewModelRegistryService(conn)
-	assertion.NotNil(err)
-	assertion.Regexp("error setting up context type odh.ServingEnvironment: rpc error: code = AlreadyExists.*", err.Error())
+	_, err = NewModelRegistryService(suite.grpcConn)
+	suite.NotNil(err)
+	suite.Regexp("error setting up context type odh.ServingEnvironment: rpc error: code = AlreadyExists.*", err.Error())
 }
 
-func TestModelRegistryFailureForOmittedFieldInInferenceService(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestModelRegistryFailureForOmittedFieldInInferenceService() {
 	inferenceServiceReq := proto.PutContextTypeRequest{
 		CanAddFields: canAddFields,
 		ContextType: &proto.ContextType{
@@ -496,19 +496,16 @@ func TestModelRegistryFailureForOmittedFieldInInferenceService(t *testing.T) {
 		},
 	}
 
-	_, err := client.PutContextType(context.Background(), &inferenceServiceReq)
-	assertion.Nil(err)
+	_, err := suite.mlmdClient.PutContextType(context.Background(), &inferenceServiceReq)
+	suite.Nil(err)
 
 	// create model registry service
-	_, err = NewModelRegistryService(conn)
-	assertion.NotNil(err)
-	assertion.Regexp("error setting up context type odh.InferenceService: rpc error: code = AlreadyExists.*", err.Error())
+	_, err = NewModelRegistryService(suite.grpcConn)
+	suite.NotNil(err)
+	suite.Regexp("error setting up context type odh.InferenceService: rpc error: code = AlreadyExists.*", err.Error())
 }
 
-func TestModelRegistryFailureForOmittedFieldInServeModel(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestModelRegistryFailureForOmittedFieldInServeModel() {
 	serveModelReq := proto.PutExecutionTypeRequest{
 		CanAddFields: canAddFields,
 		ExecutionType: &proto.ExecutionType{
@@ -519,23 +516,20 @@ func TestModelRegistryFailureForOmittedFieldInServeModel(t *testing.T) {
 		},
 	}
 
-	_, err := client.PutExecutionType(context.Background(), &serveModelReq)
-	assertion.Nil(err)
+	_, err := suite.mlmdClient.PutExecutionType(context.Background(), &serveModelReq)
+	suite.Nil(err)
 
 	// create model registry service
-	_, err = NewModelRegistryService(conn)
-	assertion.NotNil(err)
-	assertion.Regexp("error setting up execution type odh.ServeModel: rpc error: code = AlreadyExists.*", err.Error())
+	_, err = NewModelRegistryService(suite.grpcConn)
+	suite.NotNil(err)
+	suite.Regexp("error setting up execution type odh.ServeModel: rpc error: code = AlreadyExists.*", err.Error())
 }
 
 // REGISTERED MODELS
 
-func TestCreateRegisteredModel(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestCreateRegisteredModel() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	state := openapi.REGISTEREDMODELSTATE_ARCHIVED
 	// register a new model
@@ -557,35 +551,32 @@ func TestCreateRegisteredModel(t *testing.T) {
 	createdModel, err := service.UpsertRegisteredModel(registeredModel)
 
 	// checks
-	assertion.Nilf(err, "error creating registered model: %v", err)
-	assertion.NotNilf(createdModel.Id, "created registered model should not have nil Id")
+	suite.Nilf(err, "error creating registered model: %v", err)
+	suite.NotNilf(createdModel.Id, "created registered model should not have nil Id")
 
 	createdModelId, _ := converter.StringToInt64(createdModel.Id)
-	ctxById, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	ctxById, err := suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{*createdModelId},
 	})
-	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	suite.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
 
 	ctx := ctxById.Contexts[0]
 	ctxId := converter.Int64ToString(ctx.Id)
-	assertion.Equal(*createdModel.Id, *ctxId, "returned model id should match the mlmd one")
-	assertion.Equal(modelName, *ctx.Name, "saved model name should match the provided one")
-	assertion.Equal(modelExternalId, *ctx.ExternalId, "saved external id should match the provided one")
-	assertion.Equal(modelDescription, ctx.Properties["description"].GetStringValue(), "saved description should match the provided one")
-	assertion.Equal(string(state), ctx.Properties["state"].GetStringValue(), "saved state should match the provided one")
-	assertion.Equal(owner, ctx.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
+	suite.Equal(*createdModel.Id, *ctxId, "returned model id should match the mlmd one")
+	suite.Equal(modelName, *ctx.Name, "saved model name should match the provided one")
+	suite.Equal(modelExternalId, *ctx.ExternalId, "saved external id should match the provided one")
+	suite.Equal(modelDescription, ctx.Properties["description"].GetStringValue(), "saved description should match the provided one")
+	suite.Equal(string(state), ctx.Properties["state"].GetStringValue(), "saved state should match the provided one")
+	suite.Equal(owner, ctx.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
 
-	getAllResp, err := client.GetContexts(context.Background(), &proto.GetContextsRequest{})
-	assertion.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
-	assertion.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
+	getAllResp, err := suite.mlmdClient.GetContexts(context.Background(), &proto.GetContextsRequest{})
+	suite.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
+	suite.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
 }
 
-func TestUpdateRegisteredModel(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestUpdateRegisteredModel() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	// register a new model
 	registeredModel := &openapi.RegisteredModel{
@@ -604,14 +595,14 @@ func TestUpdateRegisteredModel(t *testing.T) {
 	createdModel, err := service.UpsertRegisteredModel(registeredModel)
 
 	// checks
-	assertion.Nilf(err, "error creating registered model: %v", err)
-	assertion.NotNilf(createdModel.Id, "created registered model should not have nil Id")
+	suite.Nilf(err, "error creating registered model: %v", err)
+	suite.NotNilf(createdModel.Id, "created registered model should not have nil Id")
 	createdModelId, _ := converter.StringToInt64(createdModel.Id)
 
 	// checks created model matches original one except for Id
-	assertion.Equal(*registeredModel.Name, *createdModel.Name, "returned model name should match the original one")
-	assertion.Equal(*registeredModel.ExternalID, *createdModel.ExternalID, "returned model external id should match the original one")
-	assertion.Equal(*registeredModel.CustomProperties, *createdModel.CustomProperties, "returned model custom props should match the original one")
+	suite.Equal(*registeredModel.Name, *createdModel.Name, "returned model name should match the original one")
+	suite.Equal(*registeredModel.ExternalID, *createdModel.ExternalID, "returned model external id should match the original one")
+	suite.Equal(*registeredModel.CustomProperties, *createdModel.CustomProperties, "returned model custom props should match the original one")
 
 	// update existing model
 	newModelExternalId := "newExternalId"
@@ -626,56 +617,53 @@ func TestUpdateRegisteredModel(t *testing.T) {
 
 	// update the model
 	createdModel, err = service.UpsertRegisteredModel(createdModel)
-	assertion.Nilf(err, "error creating registered model: %v", err)
+	suite.Nilf(err, "error creating registered model: %v", err)
 
 	// still one registered model
-	getAllResp, err := client.GetContexts(context.Background(), &proto.GetContextsRequest{})
-	assertion.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
-	assertion.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
+	getAllResp, err := suite.mlmdClient.GetContexts(context.Background(), &proto.GetContextsRequest{})
+	suite.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
+	suite.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
 
-	ctxById, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	ctxById, err := suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{*createdModelId},
 	})
-	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	suite.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
 
 	ctx := ctxById.Contexts[0]
 	ctxId := converter.Int64ToString(ctx.Id)
-	assertion.Equal(*createdModel.Id, *ctxId, "returned model id should match the mlmd one")
-	assertion.Equal(modelName, *ctx.Name, "saved model name should match the provided one")
-	assertion.Equal(newModelExternalId, *ctx.ExternalId, "saved external id should match the provided one")
-	assertion.Equal(newOwner, ctx.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
+	suite.Equal(*createdModel.Id, *ctxId, "returned model id should match the mlmd one")
+	suite.Equal(modelName, *ctx.Name, "saved model name should match the provided one")
+	suite.Equal(newModelExternalId, *ctx.ExternalId, "saved external id should match the provided one")
+	suite.Equal(newOwner, ctx.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
 
 	// update the model keeping nil name
 	newModelExternalId = "newNewExternalId"
 	createdModel.ExternalID = &newModelExternalId
 	createdModel.Name = nil
 	createdModel, err = service.UpsertRegisteredModel(createdModel)
-	assertion.Nilf(err, "error creating registered model: %v", err)
+	suite.Nilf(err, "error creating registered model: %v", err)
 
 	// still one registered model
-	getAllResp, err = client.GetContexts(context.Background(), &proto.GetContextsRequest{})
-	assertion.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
-	assertion.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
+	getAllResp, err = suite.mlmdClient.GetContexts(context.Background(), &proto.GetContextsRequest{})
+	suite.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
+	suite.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
 
-	ctxById, err = client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	ctxById, err = suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{*createdModelId},
 	})
-	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	suite.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
 
 	ctx = ctxById.Contexts[0]
 	ctxId = converter.Int64ToString(ctx.Id)
-	assertion.Equal(*createdModel.Id, *ctxId, "returned model id should match the mlmd one")
-	assertion.Equal(modelName, *ctx.Name, "saved model name should match the provided one")
-	assertion.Equal(newModelExternalId, *ctx.ExternalId, "saved external id should match the provided one")
-	assertion.Equal(newOwner, ctx.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
+	suite.Equal(*createdModel.Id, *ctxId, "returned model id should match the mlmd one")
+	suite.Equal(modelName, *ctx.Name, "saved model name should match the provided one")
+	suite.Equal(newModelExternalId, *ctx.ExternalId, "saved external id should match the provided one")
+	suite.Equal(newOwner, ctx.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
 }
 
-func TestGetRegisteredModelById(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetRegisteredModelById() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	state := openapi.REGISTEREDMODELSTATE_LIVE
 	// register a new model
@@ -696,36 +684,30 @@ func TestGetRegisteredModelById(t *testing.T) {
 	createdModel, err := service.UpsertRegisteredModel(registeredModel)
 
 	// checks
-	assertion.Nilf(err, "error creating registered model: %v", err)
+	suite.Nilf(err, "error creating registered model: %v", err)
 
 	getModelById, err := service.GetRegisteredModelById(*createdModel.Id)
-	assertion.Nilf(err, "error getting registered model by id %s: %v", *createdModel.Id, err)
+	suite.Nilf(err, "error getting registered model by id %s: %v", *createdModel.Id, err)
 
 	// checks created model matches original one except for Id
-	assertion.Equal(*registeredModel.Name, *getModelById.Name, "saved model name should match the original one")
-	assertion.Equal(*registeredModel.ExternalID, *getModelById.ExternalID, "saved model external id should match the original one")
-	assertion.Equal(*registeredModel.State, *getModelById.State, "saved model state should match the original one")
-	assertion.Equal(*registeredModel.CustomProperties, *getModelById.CustomProperties, "saved model custom props should match the original one")
+	suite.Equal(*registeredModel.Name, *getModelById.Name, "saved model name should match the original one")
+	suite.Equal(*registeredModel.ExternalID, *getModelById.ExternalID, "saved model external id should match the original one")
+	suite.Equal(*registeredModel.State, *getModelById.State, "saved model state should match the original one")
+	suite.Equal(*registeredModel.CustomProperties, *getModelById.CustomProperties, "saved model custom props should match the original one")
 }
 
-func TestGetRegisteredModelByParamsWithNoResults(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetRegisteredModelByParamsWithNoResults() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	_, err := service.GetRegisteredModelByParams(of("not-present"), nil)
-	assertion.NotNil(err)
-	assertion.Equal("no registered models found for name=not-present, externalId=", err.Error())
+	suite.NotNil(err)
+	suite.Equal("no registered models found for name=not-present, externalId=", err.Error())
 }
 
-func TestGetRegisteredModelByParamsName(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetRegisteredModelByParamsName() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	// register a new model
 	registeredModel := &openapi.RegisteredModel{
@@ -734,20 +716,17 @@ func TestGetRegisteredModelByParamsName(t *testing.T) {
 	}
 
 	createdModel, err := service.UpsertRegisteredModel(registeredModel)
-	assertion.Nilf(err, "error creating registered model: %v", err)
+	suite.Nilf(err, "error creating registered model: %v", err)
 
 	byName, err := service.GetRegisteredModelByParams(&modelName, nil)
-	assertion.Nilf(err, "error getting registered model by name: %v", err)
+	suite.Nilf(err, "error getting registered model by name: %v", err)
 
-	assertion.Equalf(*createdModel.Id, *byName.Id, "the returned model id should match the retrieved by name")
+	suite.Equalf(*createdModel.Id, *byName.Id, "the returned model id should match the retrieved by name")
 }
 
-func TestGetRegisteredModelByParamsExternalId(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetRegisteredModelByParamsExternalId() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	// register a new model
 	registeredModel := &openapi.RegisteredModel{
@@ -756,20 +735,17 @@ func TestGetRegisteredModelByParamsExternalId(t *testing.T) {
 	}
 
 	createdModel, err := service.UpsertRegisteredModel(registeredModel)
-	assertion.Nilf(err, "error creating registered model: %v", err)
+	suite.Nilf(err, "error creating registered model: %v", err)
 
 	byName, err := service.GetRegisteredModelByParams(nil, &modelExternalId)
-	assertion.Nilf(err, "error getting registered model by external id: %v", err)
+	suite.Nilf(err, "error getting registered model by external id: %v", err)
 
-	assertion.Equalf(*createdModel.Id, *byName.Id, "the returned model id should match the retrieved by name")
+	suite.Equalf(*createdModel.Id, *byName.Id, "the returned model id should match the retrieved by name")
 }
 
-func TestGetRegisteredModelByEmptyParams(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetRegisteredModelByEmptyParams() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	// register a new model
 	registeredModel := &openapi.RegisteredModel{
@@ -778,19 +754,16 @@ func TestGetRegisteredModelByEmptyParams(t *testing.T) {
 	}
 
 	_, err := service.UpsertRegisteredModel(registeredModel)
-	assertion.Nilf(err, "error creating registered model: %v", err)
+	suite.Nilf(err, "error creating registered model: %v", err)
 
 	_, err = service.GetRegisteredModelByParams(nil, nil)
-	assertion.NotNil(err)
-	assertion.Equal("invalid parameters call, supply either name or externalId", err.Error())
+	suite.NotNil(err)
+	suite.Equal("invalid parameters call, supply either name or externalId", err.Error())
 }
 
-func TestGetRegisteredModelsOrderedById(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetRegisteredModelsOrderedById() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	orderBy := "ID"
 
@@ -801,51 +774,48 @@ func TestGetRegisteredModelsOrderedById(t *testing.T) {
 	}
 
 	_, err := service.UpsertRegisteredModel(registeredModel)
-	assertion.Nilf(err, "error creating registered model: %v", err)
+	suite.Nilf(err, "error creating registered model: %v", err)
 
 	newModelName := "PricingModel2"
 	newModelExternalId := "myExternalId2"
 	registeredModel.Name = &newModelName
 	registeredModel.ExternalID = &newModelExternalId
 	_, err = service.UpsertRegisteredModel(registeredModel)
-	assertion.Nilf(err, "error creating registered model: %v", err)
+	suite.Nilf(err, "error creating registered model: %v", err)
 
 	newModelName = "PricingModel3"
 	newModelExternalId = "myExternalId3"
 	registeredModel.Name = &newModelName
 	registeredModel.ExternalID = &newModelExternalId
 	_, err = service.UpsertRegisteredModel(registeredModel)
-	assertion.Nilf(err, "error creating registered model: %v", err)
+	suite.Nilf(err, "error creating registered model: %v", err)
 
 	orderedById, err := service.GetRegisteredModels(api.ListOptions{
 		OrderBy:   &orderBy,
 		SortOrder: &ascOrderDirection,
 	})
-	assertion.Nilf(err, "error getting registered models: %v", err)
+	suite.Nilf(err, "error getting registered models: %v", err)
 
-	assertion.Equal(3, int(orderedById.Size))
+	suite.Equal(3, int(orderedById.Size))
 	for i := 0; i < int(orderedById.Size)-1; i++ {
-		assertion.Less(*orderedById.Items[i].Id, *orderedById.Items[i+1].Id)
+		suite.Less(*orderedById.Items[i].Id, *orderedById.Items[i+1].Id)
 	}
 
 	orderedById, err = service.GetRegisteredModels(api.ListOptions{
 		OrderBy:   &orderBy,
 		SortOrder: &descOrderDirection,
 	})
-	assertion.Nilf(err, "error getting registered models: %v", err)
+	suite.Nilf(err, "error getting registered models: %v", err)
 
-	assertion.Equal(3, int(orderedById.Size))
+	suite.Equal(3, int(orderedById.Size))
 	for i := 0; i < int(orderedById.Size)-1; i++ {
-		assertion.Greater(*orderedById.Items[i].Id, *orderedById.Items[i+1].Id)
+		suite.Greater(*orderedById.Items[i].Id, *orderedById.Items[i+1].Id)
 	}
 }
 
-func TestGetRegisteredModelsOrderedByLastUpdate(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetRegisteredModelsOrderedByLastUpdate() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	orderBy := "LAST_UPDATE_TIME"
 
@@ -856,56 +826,53 @@ func TestGetRegisteredModelsOrderedByLastUpdate(t *testing.T) {
 	}
 
 	firstModel, err := service.UpsertRegisteredModel(registeredModel)
-	assertion.Nilf(err, "error creating registered model: %v", err)
+	suite.Nilf(err, "error creating registered model: %v", err)
 
 	newModelName := "PricingModel2"
 	newModelExternalId := "myExternalId2"
 	registeredModel.Name = &newModelName
 	registeredModel.ExternalID = &newModelExternalId
 	secondModel, err := service.UpsertRegisteredModel(registeredModel)
-	assertion.Nilf(err, "error creating registered model: %v", err)
+	suite.Nilf(err, "error creating registered model: %v", err)
 
 	newModelName = "PricingModel3"
 	newModelExternalId = "myExternalId3"
 	registeredModel.Name = &newModelName
 	registeredModel.ExternalID = &newModelExternalId
 	thirdModel, err := service.UpsertRegisteredModel(registeredModel)
-	assertion.Nilf(err, "error creating registered model: %v", err)
+	suite.Nilf(err, "error creating registered model: %v", err)
 
 	// update second model
 	secondModel.ExternalID = nil
 	_, err = service.UpsertRegisteredModel(secondModel)
-	assertion.Nilf(err, "error creating registered model: %v", err)
+	suite.Nilf(err, "error creating registered model: %v", err)
 
 	orderedById, err := service.GetRegisteredModels(api.ListOptions{
 		OrderBy:   &orderBy,
 		SortOrder: &ascOrderDirection,
 	})
-	assertion.Nilf(err, "error getting registered models: %v", err)
+	suite.Nilf(err, "error getting registered models: %v", err)
 
-	assertion.Equal(3, int(orderedById.Size))
-	assertion.Equal(*firstModel.Id, *orderedById.Items[0].Id)
-	assertion.Equal(*thirdModel.Id, *orderedById.Items[1].Id)
-	assertion.Equal(*secondModel.Id, *orderedById.Items[2].Id)
+	suite.Equal(3, int(orderedById.Size))
+	suite.Equal(*firstModel.Id, *orderedById.Items[0].Id)
+	suite.Equal(*thirdModel.Id, *orderedById.Items[1].Id)
+	suite.Equal(*secondModel.Id, *orderedById.Items[2].Id)
 
 	orderedById, err = service.GetRegisteredModels(api.ListOptions{
 		OrderBy:   &orderBy,
 		SortOrder: &descOrderDirection,
 	})
-	assertion.Nilf(err, "error getting registered models: %v", err)
+	suite.Nilf(err, "error getting registered models: %v", err)
 
-	assertion.Equal(3, int(orderedById.Size))
-	assertion.Equal(*secondModel.Id, *orderedById.Items[0].Id)
-	assertion.Equal(*thirdModel.Id, *orderedById.Items[1].Id)
-	assertion.Equal(*firstModel.Id, *orderedById.Items[2].Id)
+	suite.Equal(3, int(orderedById.Size))
+	suite.Equal(*secondModel.Id, *orderedById.Items[0].Id)
+	suite.Equal(*thirdModel.Id, *orderedById.Items[1].Id)
+	suite.Equal(*firstModel.Id, *orderedById.Items[2].Id)
 }
 
-func TestGetRegisteredModelsWithPageSize(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetRegisteredModelsWithPageSize() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	pageSize := int32(1)
 	pageSize2 := int32(2)
@@ -919,53 +886,50 @@ func TestGetRegisteredModelsWithPageSize(t *testing.T) {
 	}
 
 	firstModel, err := service.UpsertRegisteredModel(registeredModel)
-	assertion.Nilf(err, "error creating registered model: %v", err)
+	suite.Nilf(err, "error creating registered model: %v", err)
 
 	newModelName := "PricingModel2"
 	newModelExternalId := "myExternalId2"
 	registeredModel.Name = &newModelName
 	registeredModel.ExternalID = &newModelExternalId
 	secondModel, err := service.UpsertRegisteredModel(registeredModel)
-	assertion.Nilf(err, "error creating registered model: %v", err)
+	suite.Nilf(err, "error creating registered model: %v", err)
 
 	newModelName = "PricingModel3"
 	newModelExternalId = "myExternalId3"
 	registeredModel.Name = &newModelName
 	registeredModel.ExternalID = &newModelExternalId
 	thirdModel, err := service.UpsertRegisteredModel(registeredModel)
-	assertion.Nilf(err, "error creating registered model: %v", err)
+	suite.Nilf(err, "error creating registered model: %v", err)
 
 	truncatedList, err := service.GetRegisteredModels(api.ListOptions{
 		PageSize: &pageSize,
 	})
-	assertion.Nilf(err, "error getting registered models: %v", err)
+	suite.Nilf(err, "error getting registered models: %v", err)
 
-	assertion.Equal(1, int(truncatedList.Size))
-	assertion.NotEqual("", truncatedList.NextPageToken, "next page token should not be empty")
-	assertion.Equal(*firstModel.Id, *truncatedList.Items[0].Id)
+	suite.Equal(1, int(truncatedList.Size))
+	suite.NotEqual("", truncatedList.NextPageToken, "next page token should not be empty")
+	suite.Equal(*firstModel.Id, *truncatedList.Items[0].Id)
 
 	truncatedList, err = service.GetRegisteredModels(api.ListOptions{
 		PageSize:      &pageSize2,
 		NextPageToken: &truncatedList.NextPageToken,
 	})
-	assertion.Nilf(err, "error getting registered models: %v", err)
+	suite.Nilf(err, "error getting registered models: %v", err)
 
-	assertion.Equal(2, int(truncatedList.Size))
-	assertion.Equal("", truncatedList.NextPageToken, "next page token should be empty as list item returned")
-	assertion.Equal(*secondModel.Id, *truncatedList.Items[0].Id)
-	assertion.Equal(*thirdModel.Id, *truncatedList.Items[1].Id)
+	suite.Equal(2, int(truncatedList.Size))
+	suite.Equal("", truncatedList.NextPageToken, "next page token should be empty as list item returned")
+	suite.Equal(*secondModel.Id, *truncatedList.Items[0].Id)
+	suite.Equal(*thirdModel.Id, *truncatedList.Items[1].Id)
 }
 
 // MODEL VERSIONS
 
-func TestCreateModelVersion(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestCreateModelVersion() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	state := openapi.MODELVERSIONSTATE_LIVE
 	modelVersion := &openapi.ModelVersion{
@@ -977,39 +941,36 @@ func TestCreateModelVersion(t *testing.T) {
 	}
 
 	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 
-	assertion.NotNilf(createdVersion.Id, "created model version should not have nil Id")
+	suite.NotNilf(createdVersion.Id, "created model version should not have nil Id")
 
 	createdVersionId, _ := converter.StringToInt64(createdVersion.Id)
 
-	byId, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	byId, err := suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{
 			*createdVersionId,
 		},
 	})
-	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
-	assertion.Equal(1, len(byId.Contexts), "there should be just one context saved in mlmd")
+	suite.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	suite.Equal(1, len(byId.Contexts), "there should be just one context saved in mlmd")
 
-	assertion.Equal(*createdVersionId, *byId.Contexts[0].Id, "returned model id should match the mlmd one")
-	assertion.Equal(fmt.Sprintf("%s:%s", registeredModelId, modelVersionName), *byId.Contexts[0].Name, "saved model name should match the provided one")
-	assertion.Equal(versionExternalId, *byId.Contexts[0].ExternalId, "saved external id should match the provided one")
-	assertion.Equal(author, byId.Contexts[0].Properties["author"].GetStringValue(), "saved author property should match the provided one")
-	assertion.Equal(modelVersionDescription, byId.Contexts[0].Properties["description"].GetStringValue(), "saved description should match the provided one")
-	assertion.Equal(string(state), byId.Contexts[0].Properties["state"].GetStringValue(), "saved state should match the provided one")
-	assertion.Equalf(*modelVersionTypeName, *byId.Contexts[0].Type, "saved context should be of type of %s", *modelVersionTypeName)
+	suite.Equal(*createdVersionId, *byId.Contexts[0].Id, "returned model id should match the mlmd one")
+	suite.Equal(fmt.Sprintf("%s:%s", registeredModelId, modelVersionName), *byId.Contexts[0].Name, "saved model name should match the provided one")
+	suite.Equal(versionExternalId, *byId.Contexts[0].ExternalId, "saved external id should match the provided one")
+	suite.Equal(author, byId.Contexts[0].Properties["author"].GetStringValue(), "saved author property should match the provided one")
+	suite.Equal(modelVersionDescription, byId.Contexts[0].Properties["description"].GetStringValue(), "saved description should match the provided one")
+	suite.Equal(string(state), byId.Contexts[0].Properties["state"].GetStringValue(), "saved state should match the provided one")
+	suite.Equalf(*modelVersionTypeName, *byId.Contexts[0].Type, "saved context should be of type of %s", *modelVersionTypeName)
 
-	getAllResp, err := client.GetContexts(context.Background(), &proto.GetContextsRequest{})
-	assertion.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
-	assertion.Equal(2, len(getAllResp.Contexts), "there should be two contexts saved in mlmd")
+	getAllResp, err := suite.mlmdClient.GetContexts(context.Background(), &proto.GetContextsRequest{})
+	suite.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
+	suite.Equal(2, len(getAllResp.Contexts), "there should be two contexts saved in mlmd")
 }
 
-func TestCreateModelVersionFailure(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestCreateModelVersionFailure() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	registeredModelId := "9999"
 
@@ -1020,22 +981,19 @@ func TestCreateModelVersionFailure(t *testing.T) {
 	}
 
 	_, err := service.UpsertModelVersion(modelVersion, nil)
-	assertion.NotNil(err)
-	assertion.Equal("missing registered model id, cannot create model version without registered model", err.Error())
+	suite.NotNil(err)
+	suite.Equal("missing registered model id, cannot create model version without registered model", err.Error())
 
 	_, err = service.UpsertModelVersion(modelVersion, &registeredModelId)
-	assertion.NotNil(err)
-	assertion.Equal("no registered model found for id 9999", err.Error())
+	suite.NotNil(err)
+	suite.Equal("no registered model found for id 9999", err.Error())
 }
 
-func TestUpdateModelVersion(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestUpdateModelVersion() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	modelVersion := &openapi.ModelVersion{
 		Name:       &modelVersionName,
@@ -1044,9 +1002,9 @@ func TestUpdateModelVersion(t *testing.T) {
 	}
 
 	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 
-	assertion.NotNilf(createdVersion.Id, "created model version should not have nil Id")
+	suite.NotNilf(createdVersion.Id, "created model version should not have nil Id")
 	createdVersionId, _ := converter.StringToInt64(createdVersion.Id)
 
 	newExternalId := "org.my_awesome_model@v1"
@@ -1060,65 +1018,61 @@ func TestUpdateModelVersion(t *testing.T) {
 	}
 
 	updatedVersion, err := service.UpsertModelVersion(createdVersion, &registeredModelId)
-	assertion.Nilf(err, "error updating new model version for %s: %v", registeredModelId, err)
+	suite.Nilf(err, "error updating new model version for %s: %v", registeredModelId, err)
 
 	updateVersionId, _ := converter.StringToInt64(updatedVersion.Id)
-	assertion.Equal(*createdVersionId, *updateVersionId, "created and updated model version should have same id")
+	suite.Equal(*createdVersionId, *updateVersionId, "created and updated model version should have same id")
 
-	byId, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	byId, err := suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{
 			*updateVersionId,
 		},
 	})
-	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
-	assertion.Equal(1, len(byId.Contexts), "there should be just one context saved in mlmd")
+	suite.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	suite.Equal(1, len(byId.Contexts), "there should be just one context saved in mlmd")
 
-	assertion.Equal(*updateVersionId, *byId.Contexts[0].Id, "returned model id should match the mlmd one")
-	assertion.Equal(fmt.Sprintf("%s:%s", registeredModelId, modelVersionName), *byId.Contexts[0].Name, "saved model name should match the provided one")
-	assertion.Equal(newExternalId, *byId.Contexts[0].ExternalId, "saved external id should match the provided one")
-	assertion.Equal(author, byId.Contexts[0].Properties["author"].GetStringValue(), "saved author property should match the provided one")
-	assertion.Equal(newScore, byId.Contexts[0].CustomProperties["score"].GetDoubleValue(), "saved score custom property should match the provided one")
-	assertion.Equalf(*modelVersionTypeName, *byId.Contexts[0].Type, "saved context should be of type of %s", *modelVersionTypeName)
+	suite.Equal(*updateVersionId, *byId.Contexts[0].Id, "returned model id should match the mlmd one")
+	suite.Equal(fmt.Sprintf("%s:%s", registeredModelId, modelVersionName), *byId.Contexts[0].Name, "saved model name should match the provided one")
+	suite.Equal(newExternalId, *byId.Contexts[0].ExternalId, "saved external id should match the provided one")
+	suite.Equal(author, byId.Contexts[0].Properties["author"].GetStringValue(), "saved author property should match the provided one")
+	suite.Equal(newScore, byId.Contexts[0].CustomProperties["score"].GetDoubleValue(), "saved score custom property should match the provided one")
+	suite.Equalf(*modelVersionTypeName, *byId.Contexts[0].Type, "saved context should be of type of %s", *modelVersionTypeName)
 
-	getAllResp, err := client.GetContexts(context.Background(), &proto.GetContextsRequest{})
-	assertion.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
-	fmt.Printf("%+v", getAllResp.Contexts)
-	assertion.Equal(2, len(getAllResp.Contexts), "there should be two contexts saved in mlmd")
+	getAllResp, err := suite.mlmdClient.GetContexts(context.Background(), &proto.GetContextsRequest{})
+	suite.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
+	suite.Equal(2, len(getAllResp.Contexts), "there should be two contexts saved in mlmd")
 
 	// update with nil name
 	newExternalId = "org.my_awesome_model_@v1"
 	updatedVersion.ExternalID = &newExternalId
 	updatedVersion.Name = nil
 	updatedVersion, err = service.UpsertModelVersion(updatedVersion, &registeredModelId)
-	assertion.Nilf(err, "error updating new model version for %s: %v", registeredModelId, err)
+	suite.Nilf(err, "error updating new model version for %s: %v", registeredModelId, err)
 
 	updateVersionId, _ = converter.StringToInt64(updatedVersion.Id)
-	assertion.Equal(*createdVersionId, *updateVersionId, "created and updated model version should have same id")
+	suite.Equal(*createdVersionId, *updateVersionId, "created and updated model version should have same id")
 
-	byId, err = client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	byId, err = suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{
 			*updateVersionId,
 		},
 	})
-	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
-	assertion.Equal(1, len(byId.Contexts), "there should be just one context saved in mlmd")
+	suite.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	suite.Equal(1, len(byId.Contexts), "there should be just one context saved in mlmd")
 
-	assertion.Equal(*updateVersionId, *byId.Contexts[0].Id, "returned model id should match the mlmd one")
-	assertion.Equal(fmt.Sprintf("%s:%s", registeredModelId, modelVersionName), *byId.Contexts[0].Name, "saved model name should match the provided one")
-	assertion.Equal(newExternalId, *byId.Contexts[0].ExternalId, "saved external id should match the provided one")
-	assertion.Equal(author, byId.Contexts[0].Properties["author"].GetStringValue(), "saved author property should match the provided one")
-	assertion.Equal(newScore, byId.Contexts[0].CustomProperties["score"].GetDoubleValue(), "saved score custom property should match the provided one")
-	assertion.Equalf(*modelVersionTypeName, *byId.Contexts[0].Type, "saved context should be of type of %s", *modelVersionTypeName)
+	suite.Equal(*updateVersionId, *byId.Contexts[0].Id, "returned model id should match the mlmd one")
+	suite.Equal(fmt.Sprintf("%s:%s", registeredModelId, modelVersionName), *byId.Contexts[0].Name, "saved model name should match the provided one")
+	suite.Equal(newExternalId, *byId.Contexts[0].ExternalId, "saved external id should match the provided one")
+	suite.Equal(author, byId.Contexts[0].Properties["author"].GetStringValue(), "saved author property should match the provided one")
+	suite.Equal(newScore, byId.Contexts[0].CustomProperties["score"].GetDoubleValue(), "saved score custom property should match the provided one")
+	suite.Equalf(*modelVersionTypeName, *byId.Contexts[0].Type, "saved context should be of type of %s", *modelVersionTypeName)
 }
 
-func TestUpdateModelVersionFailure(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestUpdateModelVersionFailure() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	modelVersion := &openapi.ModelVersion{
 		Name:       &modelVersionName,
@@ -1127,8 +1081,8 @@ func TestUpdateModelVersionFailure(t *testing.T) {
 	}
 
 	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %s", registeredModelId)
-	assertion.NotNilf(createdVersion.Id, "created model version should not have nil Id")
+	suite.Nilf(err, "error creating new model version for %s", registeredModelId)
+	suite.NotNilf(createdVersion.Id, "created model version should not have nil Id")
 
 	newExternalId := "org.my_awesome_model@v1"
 	newScore := 0.95
@@ -1143,18 +1097,15 @@ func TestUpdateModelVersionFailure(t *testing.T) {
 	wrongId := "9999"
 	createdVersion.Id = &wrongId
 	_, err = service.UpsertModelVersion(createdVersion, &registeredModelId)
-	assertion.NotNil(err)
-	assertion.Equal(fmt.Sprintf("no model version found for id %s", wrongId), err.Error())
+	suite.NotNil(err)
+	suite.Equal(fmt.Sprintf("no model version found for id %s", wrongId), err.Error())
 }
 
-func TestGetModelVersionById(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetModelVersionById() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	state := openapi.MODELVERSIONSTATE_ARCHIVED
 	modelVersion := &openapi.ModelVersion{
@@ -1165,51 +1116,45 @@ func TestGetModelVersionById(t *testing.T) {
 	}
 
 	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 
-	assertion.NotNilf(createdVersion.Id, "created model version should not have nil Id")
+	suite.NotNilf(createdVersion.Id, "created model version should not have nil Id")
 	createdVersionId, _ := converter.StringToInt64(createdVersion.Id)
 
 	getById, err := service.GetModelVersionById(*createdVersion.Id)
-	assertion.Nilf(err, "error getting model version with id %d", *createdVersionId)
+	suite.Nilf(err, "error getting model version with id %d", *createdVersionId)
 
-	ctxById, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	ctxById, err := suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{
 			*createdVersionId,
 		},
 	})
-	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	suite.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
 
 	ctx := ctxById.Contexts[0]
-	assertion.Equal(*converter.Int64ToString(ctx.Id), *getById.Id, "returned model version id should match the mlmd context one")
-	assertion.Equal(*modelVersion.Name, *getById.Name, "saved model name should match the provided one")
-	assertion.Equal(*modelVersion.ExternalID, *getById.ExternalID, "saved external id should match the provided one")
-	assertion.Equal(*modelVersion.State, *getById.State, "saved model state should match the original one")
-	assertion.Equal(*getById.Author, author, "saved author property should match the provided one")
+	suite.Equal(*converter.Int64ToString(ctx.Id), *getById.Id, "returned model version id should match the mlmd context one")
+	suite.Equal(*modelVersion.Name, *getById.Name, "saved model name should match the provided one")
+	suite.Equal(*modelVersion.ExternalID, *getById.ExternalID, "saved external id should match the provided one")
+	suite.Equal(*modelVersion.State, *getById.State, "saved model state should match the original one")
+	suite.Equal(*getById.Author, author, "saved author property should match the provided one")
 }
 
-func TestGetModelVersionByParamsWithNoResults(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetModelVersionByParamsWithNoResults() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	_, err := service.GetModelVersionByParams(of("not-present"), &registeredModelId, nil)
-	assertion.NotNil(err)
-	assertion.Equal("no model versions found for versionName=not-present, parentResourceId=1, externalId=", err.Error())
+	suite.NotNil(err)
+	suite.Equal("no model versions found for versionName=not-present, parentResourceId=1, externalId=", err.Error())
 }
 
-func TestGetModelVersionByParamsName(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetModelVersionByParamsName() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	modelVersion := &openapi.ModelVersion{
 		Name:       &modelVersionName,
@@ -1218,36 +1163,33 @@ func TestGetModelVersionByParamsName(t *testing.T) {
 	}
 
 	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 
-	assertion.NotNilf(createdVersion.Id, "created model version should not have nil Id")
+	suite.NotNilf(createdVersion.Id, "created model version should not have nil Id")
 	createdVersionId, _ := converter.StringToInt64(createdVersion.Id)
 
 	getByName, err := service.GetModelVersionByParams(&modelVersionName, &registeredModelId, nil)
-	assertion.Nilf(err, "error getting model version by name %d", *createdVersionId)
+	suite.Nilf(err, "error getting model version by name %d", *createdVersionId)
 
-	ctxById, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	ctxById, err := suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{
 			*createdVersionId,
 		},
 	})
-	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	suite.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
 
 	ctx := ctxById.Contexts[0]
-	assertion.Equal(*converter.Int64ToString(ctx.Id), *getByName.Id, "returned model version id should match the mlmd context one")
-	assertion.Equal(fmt.Sprintf("%s:%s", registeredModelId, *getByName.Name), *ctx.Name, "saved model name should match the provided one")
-	assertion.Equal(*ctx.ExternalId, *getByName.ExternalID, "saved external id should match the provided one")
-	assertion.Equal(ctx.Properties["author"].GetStringValue(), *getByName.Author, "saved author property should match the provided one")
+	suite.Equal(*converter.Int64ToString(ctx.Id), *getByName.Id, "returned model version id should match the mlmd context one")
+	suite.Equal(fmt.Sprintf("%s:%s", registeredModelId, *getByName.Name), *ctx.Name, "saved model name should match the provided one")
+	suite.Equal(*ctx.ExternalId, *getByName.ExternalID, "saved external id should match the provided one")
+	suite.Equal(ctx.Properties["author"].GetStringValue(), *getByName.Author, "saved author property should match the provided one")
 }
 
-func TestGetModelVersionByParamsExternalId(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetModelVersionByParamsExternalId() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	modelVersion := &openapi.ModelVersion{
 		Name:       &modelVersionName,
@@ -1256,36 +1198,33 @@ func TestGetModelVersionByParamsExternalId(t *testing.T) {
 	}
 
 	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 
-	assertion.NotNilf(createdVersion.Id, "created model version should not have nil Id")
+	suite.NotNilf(createdVersion.Id, "created model version should not have nil Id")
 	createdVersionId, _ := converter.StringToInt64(createdVersion.Id)
 
 	getByExternalId, err := service.GetModelVersionByParams(nil, nil, modelVersion.ExternalID)
-	assertion.Nilf(err, "error getting model version by external id %d", *modelVersion.ExternalID)
+	suite.Nilf(err, "error getting model version by external id %d", *modelVersion.ExternalID)
 
-	ctxById, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	ctxById, err := suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{
 			*createdVersionId,
 		},
 	})
-	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	suite.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
 
 	ctx := ctxById.Contexts[0]
-	assertion.Equal(*converter.Int64ToString(ctx.Id), *getByExternalId.Id, "returned model version id should match the mlmd context one")
-	assertion.Equal(fmt.Sprintf("%s:%s", registeredModelId, *getByExternalId.Name), *ctx.Name, "saved model name should match the provided one")
-	assertion.Equal(*ctx.ExternalId, *getByExternalId.ExternalID, "saved external id should match the provided one")
-	assertion.Equal(ctx.Properties["author"].GetStringValue(), *getByExternalId.Author, "saved author property should match the provided one")
+	suite.Equal(*converter.Int64ToString(ctx.Id), *getByExternalId.Id, "returned model version id should match the mlmd context one")
+	suite.Equal(fmt.Sprintf("%s:%s", registeredModelId, *getByExternalId.Name), *ctx.Name, "saved model name should match the provided one")
+	suite.Equal(*ctx.ExternalId, *getByExternalId.ExternalID, "saved external id should match the provided one")
+	suite.Equal(ctx.Properties["author"].GetStringValue(), *getByExternalId.Author, "saved author property should match the provided one")
 }
 
-func TestGetModelVersionByEmptyParams(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetModelVersionByEmptyParams() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	modelVersion := &openapi.ModelVersion{
 		Name:       &modelVersionName,
@@ -1294,22 +1233,19 @@ func TestGetModelVersionByEmptyParams(t *testing.T) {
 	}
 
 	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
-	assertion.NotNilf(createdVersion.Id, "created model version should not have nil Id")
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.NotNilf(createdVersion.Id, "created model version should not have nil Id")
 
 	_, err = service.GetModelVersionByParams(nil, nil, nil)
-	assertion.NotNil(err)
-	assertion.Equal("invalid parameters call, supply either (versionName and parentResourceId), or externalId", err.Error())
+	suite.NotNil(err)
+	suite.Equal("invalid parameters call, supply either (versionName and parentResourceId), or externalId", err.Error())
 }
 
-func TestGetModelVersions(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetModelVersions() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	modelVersion1 := &openapi.ModelVersion{
 		Name:       &modelVersionName,
@@ -1331,17 +1267,17 @@ func TestGetModelVersions(t *testing.T) {
 	}
 
 	createdVersion1, err := service.UpsertModelVersion(modelVersion1, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 
 	createdVersion2, err := service.UpsertModelVersion(modelVersion2, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 
 	createdVersion3, err := service.UpsertModelVersion(modelVersion3, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 
 	anotherRegModelName := "AnotherModel"
 	anotherRegModelExtId := "org.another"
-	anotherRegisteredModelId := registerModel(assertion, service, &anotherRegModelName, &anotherRegModelExtId)
+	anotherRegisteredModelId := suite.registerModel(service, &anotherRegModelName, &anotherRegModelExtId)
 
 	anotherModelVersionName := "v1.0"
 	anotherModelVersionExtId := "org.another@v1.0"
@@ -1351,23 +1287,23 @@ func TestGetModelVersions(t *testing.T) {
 	}
 
 	_, err = service.UpsertModelVersion(modelVersionAnother, &anotherRegisteredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", anotherRegisteredModelId)
+	suite.Nilf(err, "error creating new model version for %d", anotherRegisteredModelId)
 
 	createdVersionId1, _ := converter.StringToInt64(createdVersion1.Id)
 	createdVersionId2, _ := converter.StringToInt64(createdVersion2.Id)
 	createdVersionId3, _ := converter.StringToInt64(createdVersion3.Id)
 
 	getAll, err := service.GetModelVersions(api.ListOptions{}, nil)
-	assertion.Nilf(err, "error getting all model versions")
-	assertion.Equal(int32(4), getAll.Size, "expected four model versions across all registered models")
+	suite.Nilf(err, "error getting all model versions")
+	suite.Equal(int32(4), getAll.Size, "expected four model versions across all registered models")
 
 	getAllByRegModel, err := service.GetModelVersions(api.ListOptions{}, &registeredModelId)
-	assertion.Nilf(err, "error getting all model versions")
-	assertion.Equalf(int32(3), getAllByRegModel.Size, "expected three model versions for registered model %d", registeredModelId)
+	suite.Nilf(err, "error getting all model versions")
+	suite.Equalf(int32(3), getAllByRegModel.Size, "expected three model versions for registered model %d", registeredModelId)
 
-	assertion.Equal(*converter.Int64ToString(createdVersionId1), *getAllByRegModel.Items[0].Id)
-	assertion.Equal(*converter.Int64ToString(createdVersionId2), *getAllByRegModel.Items[1].Id)
-	assertion.Equal(*converter.Int64ToString(createdVersionId3), *getAllByRegModel.Items[2].Id)
+	suite.Equal(*converter.Int64ToString(createdVersionId1), *getAllByRegModel.Items[0].Id)
+	suite.Equal(*converter.Int64ToString(createdVersionId2), *getAllByRegModel.Items[1].Id)
+	suite.Equal(*converter.Int64ToString(createdVersionId3), *getAllByRegModel.Items[2].Id)
 
 	// order by last update time, expecting last created as first
 	orderByLastUpdate := "LAST_UPDATE_TIME"
@@ -1375,43 +1311,40 @@ func TestGetModelVersions(t *testing.T) {
 		OrderBy:   &orderByLastUpdate,
 		SortOrder: &descOrderDirection,
 	}, &registeredModelId)
-	assertion.Nilf(err, "error getting all model versions")
-	assertion.Equalf(int32(3), getAllByRegModel.Size, "expected three model versions for registered model %d", registeredModelId)
+	suite.Nilf(err, "error getting all model versions")
+	suite.Equalf(int32(3), getAllByRegModel.Size, "expected three model versions for registered model %d", registeredModelId)
 
-	assertion.Equal(*converter.Int64ToString(createdVersionId1), *getAllByRegModel.Items[2].Id)
-	assertion.Equal(*converter.Int64ToString(createdVersionId2), *getAllByRegModel.Items[1].Id)
-	assertion.Equal(*converter.Int64ToString(createdVersionId3), *getAllByRegModel.Items[0].Id)
+	suite.Equal(*converter.Int64ToString(createdVersionId1), *getAllByRegModel.Items[2].Id)
+	suite.Equal(*converter.Int64ToString(createdVersionId2), *getAllByRegModel.Items[1].Id)
+	suite.Equal(*converter.Int64ToString(createdVersionId3), *getAllByRegModel.Items[0].Id)
 
 	// update the second version
 	newVersionExternalId := "updated.org:v2"
 	createdVersion2.ExternalID = &newVersionExternalId
 	createdVersion2, err = service.UpsertModelVersion(createdVersion2, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 
-	assertion.Equal(newVersionExternalId, *createdVersion2.ExternalID)
+	suite.Equal(newVersionExternalId, *createdVersion2.ExternalID)
 
 	getAllByRegModel, err = service.GetModelVersions(api.ListOptions{
 		OrderBy:   &orderByLastUpdate,
 		SortOrder: &descOrderDirection,
 	}, &registeredModelId)
-	assertion.Nilf(err, "error getting all model versions")
-	assertion.Equalf(int32(3), getAllByRegModel.Size, "expected three model versions for registered model %d", registeredModelId)
+	suite.Nilf(err, "error getting all model versions")
+	suite.Equalf(int32(3), getAllByRegModel.Size, "expected three model versions for registered model %d", registeredModelId)
 
-	assertion.Equal(*converter.Int64ToString(createdVersionId1), *getAllByRegModel.Items[2].Id)
-	assertion.Equal(*converter.Int64ToString(createdVersionId2), *getAllByRegModel.Items[0].Id)
-	assertion.Equal(*converter.Int64ToString(createdVersionId3), *getAllByRegModel.Items[1].Id)
+	suite.Equal(*converter.Int64ToString(createdVersionId1), *getAllByRegModel.Items[2].Id)
+	suite.Equal(*converter.Int64ToString(createdVersionId2), *getAllByRegModel.Items[0].Id)
+	suite.Equal(*converter.Int64ToString(createdVersionId3), *getAllByRegModel.Items[1].Id)
 }
 
 // MODEL ARTIFACTS
 
-func TestCreateModelArtifact(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestCreateModelArtifact() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	modelVersionId := registerModelVersion(assertion, service, nil, nil, nil, nil)
+	modelVersionId := suite.registerModelVersion(service, nil, nil, nil, nil)
 
 	modelArtifact := &openapi.ModelArtifact{
 		Name:               &artifactName,
@@ -1432,51 +1365,48 @@ func TestCreateModelArtifact(t *testing.T) {
 	}
 
 	createdArtifact, err := service.UpsertModelArtifact(modelArtifact, &modelVersionId)
-	assertion.Nilf(err, "error creating new model artifact for %d", modelVersionId)
+	suite.Nilf(err, "error creating new model artifact for %d", modelVersionId)
 
 	state, _ := openapi.NewArtifactStateFromValue(artifactState)
-	assertion.NotNil(createdArtifact.Id, "created artifact id should not be nil")
-	assertion.Equal(artifactName, *createdArtifact.Name)
-	assertion.Equal(*state, *createdArtifact.State)
-	assertion.Equal(artifactUri, *createdArtifact.Uri)
-	assertion.Equal(artifactDescription, *createdArtifact.Description)
-	assertion.Equal("onnx", *createdArtifact.ModelFormatName)
-	assertion.Equal("1", *createdArtifact.ModelFormatVersion)
-	assertion.Equal("aws-connection-models", *createdArtifact.StorageKey)
-	assertion.Equal("bucket", *createdArtifact.StoragePath)
-	assertion.Equal(customString, *(*createdArtifact.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue)
+	suite.NotNil(createdArtifact.Id, "created artifact id should not be nil")
+	suite.Equal(artifactName, *createdArtifact.Name)
+	suite.Equal(*state, *createdArtifact.State)
+	suite.Equal(artifactUri, *createdArtifact.Uri)
+	suite.Equal(artifactDescription, *createdArtifact.Description)
+	suite.Equal("onnx", *createdArtifact.ModelFormatName)
+	suite.Equal("1", *createdArtifact.ModelFormatVersion)
+	suite.Equal("aws-connection-models", *createdArtifact.StorageKey)
+	suite.Equal("bucket", *createdArtifact.StoragePath)
+	suite.Equal(customString, *(*createdArtifact.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue)
 
 	createdArtifactId, _ := converter.StringToInt64(createdArtifact.Id)
-	getById, err := client.GetArtifactsByID(context.Background(), &proto.GetArtifactsByIDRequest{
+	getById, err := suite.mlmdClient.GetArtifactsByID(context.Background(), &proto.GetArtifactsByIDRequest{
 		ArtifactIds: []int64{*createdArtifactId},
 	})
-	assertion.Nilf(err, "error getting model artifact by id %d", createdArtifactId)
+	suite.Nilf(err, "error getting model artifact by id %d", createdArtifactId)
 
-	assertion.Equal(*createdArtifactId, *getById.Artifacts[0].Id)
-	assertion.Equal(fmt.Sprintf("%s:%s", modelVersionId, *createdArtifact.Name), *getById.Artifacts[0].Name)
-	assertion.Equal(string(*createdArtifact.State), getById.Artifacts[0].State.String())
-	assertion.Equal(*createdArtifact.Uri, *getById.Artifacts[0].Uri)
-	assertion.Equal(*createdArtifact.Description, getById.Artifacts[0].Properties["description"].GetStringValue())
-	assertion.Equal(*createdArtifact.ModelFormatName, getById.Artifacts[0].Properties["model_format_name"].GetStringValue())
-	assertion.Equal(*createdArtifact.ModelFormatVersion, getById.Artifacts[0].Properties["model_format_version"].GetStringValue())
-	assertion.Equal(*createdArtifact.StorageKey, getById.Artifacts[0].Properties["storage_key"].GetStringValue())
-	assertion.Equal(*createdArtifact.StoragePath, getById.Artifacts[0].Properties["storage_path"].GetStringValue())
-	assertion.Equal(*(*createdArtifact.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue, getById.Artifacts[0].CustomProperties["custom_string_prop"].GetStringValue())
+	suite.Equal(*createdArtifactId, *getById.Artifacts[0].Id)
+	suite.Equal(fmt.Sprintf("%s:%s", modelVersionId, *createdArtifact.Name), *getById.Artifacts[0].Name)
+	suite.Equal(string(*createdArtifact.State), getById.Artifacts[0].State.String())
+	suite.Equal(*createdArtifact.Uri, *getById.Artifacts[0].Uri)
+	suite.Equal(*createdArtifact.Description, getById.Artifacts[0].Properties["description"].GetStringValue())
+	suite.Equal(*createdArtifact.ModelFormatName, getById.Artifacts[0].Properties["model_format_name"].GetStringValue())
+	suite.Equal(*createdArtifact.ModelFormatVersion, getById.Artifacts[0].Properties["model_format_version"].GetStringValue())
+	suite.Equal(*createdArtifact.StorageKey, getById.Artifacts[0].Properties["storage_key"].GetStringValue())
+	suite.Equal(*createdArtifact.StoragePath, getById.Artifacts[0].Properties["storage_path"].GetStringValue())
+	suite.Equal(*(*createdArtifact.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue, getById.Artifacts[0].CustomProperties["custom_string_prop"].GetStringValue())
 
 	modelVersionIdAsInt, _ := converter.StringToInt64(&modelVersionId)
-	byCtx, _ := client.GetArtifactsByContext(context.Background(), &proto.GetArtifactsByContextRequest{
+	byCtx, _ := suite.mlmdClient.GetArtifactsByContext(context.Background(), &proto.GetArtifactsByContextRequest{
 		ContextId: (*int64)(modelVersionIdAsInt),
 	})
-	assertion.Equal(1, len(byCtx.Artifacts))
-	assertion.Equal(*createdArtifactId, *byCtx.Artifacts[0].Id)
+	suite.Equal(1, len(byCtx.Artifacts))
+	suite.Equal(*createdArtifactId, *byCtx.Artifacts[0].Id)
 }
 
-func TestCreateModelArtifactFailure(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestCreateModelArtifactFailure() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	modelVersionId := "9998"
 
@@ -1494,22 +1424,19 @@ func TestCreateModelArtifactFailure(t *testing.T) {
 	}
 
 	_, err := service.UpsertModelArtifact(modelArtifact, nil)
-	assertion.NotNil(err)
-	assertion.Equal("missing model version id, cannot create model artifact without model version", err.Error())
+	suite.NotNil(err)
+	suite.Equal("missing model version id, cannot create model artifact without model version", err.Error())
 
 	_, err = service.UpsertModelArtifact(modelArtifact, &modelVersionId)
-	assertion.NotNil(err)
-	assertion.Equal("no model version found for id 9998", err.Error())
+	suite.NotNil(err)
+	suite.Equal("no model version found for id 9998", err.Error())
 }
 
-func TestUpdateModelArtifact(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestUpdateModelArtifact() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	modelVersionId := registerModelVersion(assertion, service, nil, nil, nil, nil)
+	modelVersionId := suite.registerModelVersion(service, nil, nil, nil, nil)
 
 	modelArtifact := &openapi.ModelArtifact{
 		Name:  &artifactName,
@@ -1525,37 +1452,34 @@ func TestUpdateModelArtifact(t *testing.T) {
 	}
 
 	createdArtifact, err := service.UpsertModelArtifact(modelArtifact, &modelVersionId)
-	assertion.Nilf(err, "error creating new model artifact for %d", modelVersionId)
+	suite.Nilf(err, "error creating new model artifact for %d", modelVersionId)
 
 	newState := "MARKED_FOR_DELETION"
 	createdArtifact.State = (*openapi.ArtifactState)(&newState)
 	updatedArtifact, err := service.UpsertModelArtifact(createdArtifact, &modelVersionId)
-	assertion.Nilf(err, "error updating model artifact for %d: %v", modelVersionId, err)
+	suite.Nilf(err, "error updating model artifact for %d: %v", modelVersionId, err)
 
 	createdArtifactId, _ := converter.StringToInt64(createdArtifact.Id)
 	updatedArtifactId, _ := converter.StringToInt64(updatedArtifact.Id)
-	assertion.Equal(createdArtifactId, updatedArtifactId)
+	suite.Equal(createdArtifactId, updatedArtifactId)
 
-	getById, err := client.GetArtifactsByID(context.Background(), &proto.GetArtifactsByIDRequest{
+	getById, err := suite.mlmdClient.GetArtifactsByID(context.Background(), &proto.GetArtifactsByIDRequest{
 		ArtifactIds: []int64{*createdArtifactId},
 	})
-	assertion.Nilf(err, "error getting model artifact by id %d", createdArtifactId)
+	suite.Nilf(err, "error getting model artifact by id %d", createdArtifactId)
 
-	assertion.Equal(*createdArtifactId, *getById.Artifacts[0].Id)
-	assertion.Equal(fmt.Sprintf("%s:%s", modelVersionId, *createdArtifact.Name), *getById.Artifacts[0].Name)
-	assertion.Equal(string(newState), getById.Artifacts[0].State.String())
-	assertion.Equal(*createdArtifact.Uri, *getById.Artifacts[0].Uri)
-	assertion.Equal(*(*createdArtifact.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue, getById.Artifacts[0].CustomProperties["custom_string_prop"].GetStringValue())
+	suite.Equal(*createdArtifactId, *getById.Artifacts[0].Id)
+	suite.Equal(fmt.Sprintf("%s:%s", modelVersionId, *createdArtifact.Name), *getById.Artifacts[0].Name)
+	suite.Equal(string(newState), getById.Artifacts[0].State.String())
+	suite.Equal(*createdArtifact.Uri, *getById.Artifacts[0].Uri)
+	suite.Equal(*(*createdArtifact.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue, getById.Artifacts[0].CustomProperties["custom_string_prop"].GetStringValue())
 }
 
-func TestUpdateModelArtifactFailure(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestUpdateModelArtifactFailure() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	modelVersionId := registerModelVersion(assertion, service, nil, nil, nil, nil)
+	modelVersionId := suite.registerModelVersion(service, nil, nil, nil, nil)
 
 	modelArtifact := &openapi.ModelArtifact{
 		Name:  &artifactName,
@@ -1571,29 +1495,26 @@ func TestUpdateModelArtifactFailure(t *testing.T) {
 	}
 
 	createdArtifact, err := service.UpsertModelArtifact(modelArtifact, &modelVersionId)
-	assertion.Nilf(err, "error creating new model artifact for model version %s", modelVersionId)
-	assertion.NotNilf(createdArtifact.Id, "created model artifact should not have nil Id")
+	suite.Nilf(err, "error creating new model artifact for model version %s", modelVersionId)
+	suite.NotNilf(createdArtifact.Id, "created model artifact should not have nil Id")
 
 	newState := "MARKED_FOR_DELETION"
 	createdArtifact.State = (*openapi.ArtifactState)(&newState)
 	updatedArtifact, err := service.UpsertModelArtifact(createdArtifact, &modelVersionId)
-	assertion.Nilf(err, "error updating model artifact for %d: %v", modelVersionId, err)
+	suite.Nilf(err, "error updating model artifact for %d: %v", modelVersionId, err)
 
 	wrongId := "9998"
 	updatedArtifact.Id = &wrongId
 	_, err = service.UpsertModelArtifact(updatedArtifact, &modelVersionId)
-	assertion.NotNil(err)
-	assertion.Equal(fmt.Sprintf("no model artifact found for id %s", wrongId), err.Error())
+	suite.NotNil(err)
+	suite.Equal(fmt.Sprintf("no model artifact found for id %s", wrongId), err.Error())
 }
 
-func TestGetModelArtifactById(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetModelArtifactById() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	modelVersionId := registerModelVersion(assertion, service, nil, nil, nil, nil)
+	modelVersionId := suite.registerModelVersion(service, nil, nil, nil, nil)
 
 	modelArtifact := &openapi.ModelArtifact{
 		Name:  &artifactName,
@@ -1609,31 +1530,28 @@ func TestGetModelArtifactById(t *testing.T) {
 	}
 
 	createdArtifact, err := service.UpsertModelArtifact(modelArtifact, &modelVersionId)
-	assertion.Nilf(err, "error creating new model artifact for %d", modelVersionId)
+	suite.Nilf(err, "error creating new model artifact for %d", modelVersionId)
 
 	createdArtifactId, _ := converter.StringToInt64(createdArtifact.Id)
 
 	getById, err := service.GetModelArtifactById(*createdArtifact.Id)
-	assertion.Nilf(err, "error getting model artifact by id %d", createdArtifactId)
+	suite.Nilf(err, "error getting model artifact by id %d", createdArtifactId)
 
 	state, _ := openapi.NewArtifactStateFromValue(artifactState)
-	assertion.NotNil(createdArtifact.Id, "created artifact id should not be nil")
-	assertion.Equal(artifactName, *getById.Name)
-	assertion.Equal(*state, *getById.State)
-	assertion.Equal(artifactUri, *getById.Uri)
-	assertion.Equal(customString, *(*getById.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue)
+	suite.NotNil(createdArtifact.Id, "created artifact id should not be nil")
+	suite.Equal(artifactName, *getById.Name)
+	suite.Equal(*state, *getById.State)
+	suite.Equal(artifactUri, *getById.Uri)
+	suite.Equal(customString, *(*getById.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue)
 
-	assertion.Equal(*createdArtifact, *getById, "artifacts returned during creation and on get by id should be equal")
+	suite.Equal(*createdArtifact, *getById, "artifacts returned during creation and on get by id should be equal")
 }
 
-func TestGetModelArtifactByParams(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetModelArtifactByParams() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	modelVersionId := registerModelVersion(assertion, service, nil, nil, nil, nil)
+	modelVersionId := suite.registerModelVersion(service, nil, nil, nil, nil)
 
 	modelArtifact := &openapi.ModelArtifact{
 		Name:       &artifactName,
@@ -1650,45 +1568,42 @@ func TestGetModelArtifactByParams(t *testing.T) {
 	}
 
 	createdArtifact, err := service.UpsertModelArtifact(modelArtifact, &modelVersionId)
-	assertion.Nilf(err, "error creating new model artifact for %d", modelVersionId)
+	suite.Nilf(err, "error creating new model artifact for %d", modelVersionId)
 
 	createdArtifactId, _ := converter.StringToInt64(createdArtifact.Id)
 
 	state, _ := openapi.NewArtifactStateFromValue(artifactState)
 
 	getByName, err := service.GetModelArtifactByParams(&artifactName, &modelVersionId, nil)
-	assertion.Nilf(err, "error getting model artifact by id %d", createdArtifactId)
+	suite.Nilf(err, "error getting model artifact by id %d", createdArtifactId)
 
-	assertion.NotNil(createdArtifact.Id, "created artifact id should not be nil")
-	assertion.Equal(artifactName, *getByName.Name)
-	assertion.Equal(artifactExtId, *getByName.ExternalID)
-	assertion.Equal(*state, *getByName.State)
-	assertion.Equal(artifactUri, *getByName.Uri)
-	assertion.Equal(customString, *(*getByName.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue)
+	suite.NotNil(createdArtifact.Id, "created artifact id should not be nil")
+	suite.Equal(artifactName, *getByName.Name)
+	suite.Equal(artifactExtId, *getByName.ExternalID)
+	suite.Equal(*state, *getByName.State)
+	suite.Equal(artifactUri, *getByName.Uri)
+	suite.Equal(customString, *(*getByName.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue)
 
-	assertion.Equal(*createdArtifact, *getByName, "artifacts returned during creation and on get by name should be equal")
+	suite.Equal(*createdArtifact, *getByName, "artifacts returned during creation and on get by name should be equal")
 
 	getByExtId, err := service.GetModelArtifactByParams(nil, nil, &artifactExtId)
-	assertion.Nilf(err, "error getting model artifact by id %d", createdArtifactId)
+	suite.Nilf(err, "error getting model artifact by id %d", createdArtifactId)
 
-	assertion.NotNil(createdArtifact.Id, "created artifact id should not be nil")
-	assertion.Equal(artifactName, *getByExtId.Name)
-	assertion.Equal(artifactExtId, *getByExtId.ExternalID)
-	assertion.Equal(*state, *getByExtId.State)
-	assertion.Equal(artifactUri, *getByExtId.Uri)
-	assertion.Equal(customString, *(*getByExtId.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue)
+	suite.NotNil(createdArtifact.Id, "created artifact id should not be nil")
+	suite.Equal(artifactName, *getByExtId.Name)
+	suite.Equal(artifactExtId, *getByExtId.ExternalID)
+	suite.Equal(*state, *getByExtId.State)
+	suite.Equal(artifactUri, *getByExtId.Uri)
+	suite.Equal(customString, *(*getByExtId.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue)
 
-	assertion.Equal(*createdArtifact, *getByExtId, "artifacts returned during creation and on get by ext id should be equal")
+	suite.Equal(*createdArtifact, *getByExtId, "artifacts returned during creation and on get by ext id should be equal")
 }
 
-func TestGetModelArtifactByEmptyParams(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetModelArtifactByEmptyParams() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	modelVersionId := registerModelVersion(assertion, service, nil, nil, nil, nil)
+	modelVersionId := suite.registerModelVersion(service, nil, nil, nil, nil)
 
 	modelArtifact := &openapi.ModelArtifact{
 		Name:       &artifactName,
@@ -1705,35 +1620,29 @@ func TestGetModelArtifactByEmptyParams(t *testing.T) {
 	}
 
 	_, err := service.UpsertModelArtifact(modelArtifact, &modelVersionId)
-	assertion.Nilf(err, "error creating new model artifact for %d", modelVersionId)
+	suite.Nilf(err, "error creating new model artifact for %d", modelVersionId)
 
 	_, err = service.GetModelArtifactByParams(nil, nil, nil)
-	assertion.NotNil(err)
-	assertion.Equal("invalid parameters call, supply either (artifactName and parentResourceId), or externalId", err.Error())
+	suite.NotNil(err)
+	suite.Equal("invalid parameters call, supply either (artifactName and parentResourceId), or externalId", err.Error())
 }
 
-func TestGetModelArtifactByParamsWithNoResults(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetModelArtifactByParamsWithNoResults() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	modelVersionId := registerModelVersion(assertion, service, nil, nil, nil, nil)
+	modelVersionId := suite.registerModelVersion(service, nil, nil, nil, nil)
 
 	_, err := service.GetModelArtifactByParams(of("not-present"), &modelVersionId, nil)
-	assertion.NotNil(err)
-	assertion.Equal("no model artifacts found for artifactName=not-present, parentResourceId=2, externalId=", err.Error())
+	suite.NotNil(err)
+	suite.Equal("no model artifacts found for artifactName=not-present, parentResourceId=2, externalId=", err.Error())
 }
 
-func TestGetModelArtifacts(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetModelArtifacts() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	modelVersionId := registerModelVersion(assertion, service, nil, nil, nil, nil)
+	modelVersionId := suite.registerModelVersion(service, nil, nil, nil, nil)
 
 	modelArtifact1 := &openapi.ModelArtifact{
 		Name:       &artifactName,
@@ -1784,45 +1693,42 @@ func TestGetModelArtifacts(t *testing.T) {
 	}
 
 	createdArtifact1, err := service.UpsertModelArtifact(modelArtifact1, &modelVersionId)
-	assertion.Nilf(err, "error creating new model artifact for %d", modelVersionId)
+	suite.Nilf(err, "error creating new model artifact for %d", modelVersionId)
 	createdArtifact2, err := service.UpsertModelArtifact(modelArtifact2, &modelVersionId)
-	assertion.Nilf(err, "error creating new model artifact for %d", modelVersionId)
+	suite.Nilf(err, "error creating new model artifact for %d", modelVersionId)
 	createdArtifact3, err := service.UpsertModelArtifact(modelArtifact3, &modelVersionId)
-	assertion.Nilf(err, "error creating new model artifact for %d", modelVersionId)
+	suite.Nilf(err, "error creating new model artifact for %d", modelVersionId)
 
 	createdArtifactId1, _ := converter.StringToInt64(createdArtifact1.Id)
 	createdArtifactId2, _ := converter.StringToInt64(createdArtifact2.Id)
 	createdArtifactId3, _ := converter.StringToInt64(createdArtifact3.Id)
 
 	getAll, err := service.GetModelArtifacts(api.ListOptions{}, nil)
-	assertion.Nilf(err, "error getting all model artifacts")
-	assertion.Equalf(int32(3), getAll.Size, "expected three model artifacts")
+	suite.Nilf(err, "error getting all model artifacts")
+	suite.Equalf(int32(3), getAll.Size, "expected three model artifacts")
 
-	assertion.Equal(*converter.Int64ToString(createdArtifactId1), *getAll.Items[0].Id)
-	assertion.Equal(*converter.Int64ToString(createdArtifactId2), *getAll.Items[1].Id)
-	assertion.Equal(*converter.Int64ToString(createdArtifactId3), *getAll.Items[2].Id)
+	suite.Equal(*converter.Int64ToString(createdArtifactId1), *getAll.Items[0].Id)
+	suite.Equal(*converter.Int64ToString(createdArtifactId2), *getAll.Items[1].Id)
+	suite.Equal(*converter.Int64ToString(createdArtifactId3), *getAll.Items[2].Id)
 
 	orderByLastUpdate := "LAST_UPDATE_TIME"
 	getAllByModelVersion, err := service.GetModelArtifacts(api.ListOptions{
 		OrderBy:   &orderByLastUpdate,
 		SortOrder: &descOrderDirection,
 	}, &modelVersionId)
-	assertion.Nilf(err, "error getting all model artifacts for %d", modelVersionId)
-	assertion.Equalf(int32(3), getAllByModelVersion.Size, "expected three model artifacts for model version %d", modelVersionId)
+	suite.Nilf(err, "error getting all model artifacts for %d", modelVersionId)
+	suite.Equalf(int32(3), getAllByModelVersion.Size, "expected three model artifacts for model version %d", modelVersionId)
 
-	assertion.Equal(*converter.Int64ToString(createdArtifactId1), *getAllByModelVersion.Items[2].Id)
-	assertion.Equal(*converter.Int64ToString(createdArtifactId2), *getAllByModelVersion.Items[1].Id)
-	assertion.Equal(*converter.Int64ToString(createdArtifactId3), *getAllByModelVersion.Items[0].Id)
+	suite.Equal(*converter.Int64ToString(createdArtifactId1), *getAllByModelVersion.Items[2].Id)
+	suite.Equal(*converter.Int64ToString(createdArtifactId2), *getAllByModelVersion.Items[1].Id)
+	suite.Equal(*converter.Int64ToString(createdArtifactId3), *getAllByModelVersion.Items[0].Id)
 }
 
 // SERVING ENVIRONMENT
 
-func TestCreateServingEnvironment(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestCreateServingEnvironment() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	// register a new ServingEnvironment
 	eut := &openapi.ServingEnvironment{
@@ -1842,34 +1748,31 @@ func TestCreateServingEnvironment(t *testing.T) {
 	createdEntity, err := service.UpsertServingEnvironment(eut)
 
 	// checks
-	assertion.Nilf(err, "error creating uut: %v", err)
-	assertion.NotNilf(createdEntity.Id, "created uut should not have nil Id")
+	suite.Nilf(err, "error creating uut: %v", err)
+	suite.NotNilf(createdEntity.Id, "created uut should not have nil Id")
 
 	createdEntityId, _ := converter.StringToInt64(createdEntity.Id)
-	ctxById, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	ctxById, err := suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{*createdEntityId},
 	})
-	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	suite.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
 
 	ctx := ctxById.Contexts[0]
 	ctxId := converter.Int64ToString(ctx.Id)
-	assertion.Equal(*createdEntity.Id, *ctxId, "returned id should match the mlmd one")
-	assertion.Equal(entityName, *ctx.Name, "saved name should match the provided one")
-	assertion.Equal(entityExternalId, *ctx.ExternalId, "saved external id should match the provided one")
-	assertion.Equal(entityDescription, ctx.Properties["description"].GetStringValue(), "saved description should match the provided one")
-	assertion.Equal(owner, ctx.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
+	suite.Equal(*createdEntity.Id, *ctxId, "returned id should match the mlmd one")
+	suite.Equal(entityName, *ctx.Name, "saved name should match the provided one")
+	suite.Equal(entityExternalId, *ctx.ExternalId, "saved external id should match the provided one")
+	suite.Equal(entityDescription, ctx.Properties["description"].GetStringValue(), "saved description should match the provided one")
+	suite.Equal(owner, ctx.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
 
-	getAllResp, err := client.GetContexts(context.Background(), &proto.GetContextsRequest{})
-	assertion.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
-	assertion.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
+	getAllResp, err := suite.mlmdClient.GetContexts(context.Background(), &proto.GetContextsRequest{})
+	suite.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
+	suite.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
 }
 
-func TestUpdateServingEnvironment(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestUpdateServingEnvironment() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	// register a new ServingEnvironment
 	eut := &openapi.ServingEnvironment{
@@ -1888,14 +1791,14 @@ func TestUpdateServingEnvironment(t *testing.T) {
 	createdEntity, err := service.UpsertServingEnvironment(eut)
 
 	// checks
-	assertion.Nilf(err, "error creating uut: %v", err)
-	assertion.NotNilf(createdEntity.Id, "created uut should not have nil Id")
+	suite.Nilf(err, "error creating uut: %v", err)
+	suite.NotNilf(createdEntity.Id, "created uut should not have nil Id")
 	createdEntityId, _ := converter.StringToInt64(createdEntity.Id)
 
 	// checks created entity matches original one except for Id
-	assertion.Equal(*eut.Name, *createdEntity.Name, "returned entity should match the original one")
-	assertion.Equal(*eut.ExternalID, *createdEntity.ExternalID, "returned entity external id should match the original one")
-	assertion.Equal(*eut.CustomProperties, *createdEntity.CustomProperties, "returned entity custom props should match the original one")
+	suite.Equal(*eut.Name, *createdEntity.Name, "returned entity should match the original one")
+	suite.Equal(*eut.ExternalID, *createdEntity.ExternalID, "returned entity external id should match the original one")
+	suite.Equal(*eut.CustomProperties, *createdEntity.CustomProperties, "returned entity custom props should match the original one")
 
 	// update existing entity
 	newExternalId := "newExternalId"
@@ -1910,56 +1813,53 @@ func TestUpdateServingEnvironment(t *testing.T) {
 
 	// update the entity
 	createdEntity, err = service.UpsertServingEnvironment(createdEntity)
-	assertion.Nilf(err, "error creating uut: %v", err)
+	suite.Nilf(err, "error creating uut: %v", err)
 
 	// still one expected MLMD type
-	getAllResp, err := client.GetContexts(context.Background(), &proto.GetContextsRequest{})
-	assertion.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
-	assertion.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
+	getAllResp, err := suite.mlmdClient.GetContexts(context.Background(), &proto.GetContextsRequest{})
+	suite.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
+	suite.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
 
-	ctxById, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	ctxById, err := suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{*createdEntityId},
 	})
-	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	suite.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
 
 	ctx := ctxById.Contexts[0]
 	ctxId := converter.Int64ToString(ctx.Id)
-	assertion.Equal(*createdEntity.Id, *ctxId, "returned entity id should match the mlmd one")
-	assertion.Equal(entityName, *ctx.Name, "saved entity name should match the provided one")
-	assertion.Equal(newExternalId, *ctx.ExternalId, "saved external id should match the provided one")
-	assertion.Equal(newOwner, ctx.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
+	suite.Equal(*createdEntity.Id, *ctxId, "returned entity id should match the mlmd one")
+	suite.Equal(entityName, *ctx.Name, "saved entity name should match the provided one")
+	suite.Equal(newExternalId, *ctx.ExternalId, "saved external id should match the provided one")
+	suite.Equal(newOwner, ctx.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
 
 	// update the entity under test, keeping nil name
 	newExternalId = "newNewExternalId"
 	createdEntity.ExternalID = &newExternalId
 	createdEntity.Name = nil
 	createdEntity, err = service.UpsertServingEnvironment(createdEntity)
-	assertion.Nilf(err, "error creating entity: %v", err)
+	suite.Nilf(err, "error creating entity: %v", err)
 
 	// still one registered entity
-	getAllResp, err = client.GetContexts(context.Background(), &proto.GetContextsRequest{})
-	assertion.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
-	assertion.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
+	getAllResp, err = suite.mlmdClient.GetContexts(context.Background(), &proto.GetContextsRequest{})
+	suite.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
+	suite.Equal(1, len(getAllResp.Contexts), "there should be just one context saved in mlmd")
 
-	ctxById, err = client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	ctxById, err = suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{*createdEntityId},
 	})
-	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	suite.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
 
 	ctx = ctxById.Contexts[0]
 	ctxId = converter.Int64ToString(ctx.Id)
-	assertion.Equal(*createdEntity.Id, *ctxId, "returned entity id should match the mlmd one")
-	assertion.Equal(entityName, *ctx.Name, "saved entity name should match the provided one")
-	assertion.Equal(newExternalId, *ctx.ExternalId, "saved external id should match the provided one")
-	assertion.Equal(newOwner, ctx.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
+	suite.Equal(*createdEntity.Id, *ctxId, "returned entity id should match the mlmd one")
+	suite.Equal(entityName, *ctx.Name, "saved entity name should match the provided one")
+	suite.Equal(newExternalId, *ctx.ExternalId, "saved external id should match the provided one")
+	suite.Equal(newOwner, ctx.CustomProperties["owner"].GetStringValue(), "saved owner custom property should match the provided one")
 }
 
-func TestGetServingEnvironmentById(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetServingEnvironmentById() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	// register a new entity
 	eut := &openapi.ServingEnvironment{
@@ -1978,35 +1878,29 @@ func TestGetServingEnvironmentById(t *testing.T) {
 	createdEntity, err := service.UpsertServingEnvironment(eut)
 
 	// checks
-	assertion.Nilf(err, "error creating eut: %v", err)
+	suite.Nilf(err, "error creating eut: %v", err)
 
 	getEntityById, err := service.GetServingEnvironmentById(*createdEntity.Id)
-	assertion.Nilf(err, "error getting eut by id %s: %v", *createdEntity.Id, err)
+	suite.Nilf(err, "error getting eut by id %s: %v", *createdEntity.Id, err)
 
 	// checks created entity matches original one except for Id
-	assertion.Equal(*eut.Name, *getEntityById.Name, "saved name should match the original one")
-	assertion.Equal(*eut.ExternalID, *getEntityById.ExternalID, "saved external id should match the original one")
-	assertion.Equal(*eut.CustomProperties, *getEntityById.CustomProperties, "saved custom props should match the original one")
+	suite.Equal(*eut.Name, *getEntityById.Name, "saved name should match the original one")
+	suite.Equal(*eut.ExternalID, *getEntityById.ExternalID, "saved external id should match the original one")
+	suite.Equal(*eut.CustomProperties, *getEntityById.CustomProperties, "saved custom props should match the original one")
 }
 
-func TestGetServingEnvironmentByParamsWithNoResults(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetServingEnvironmentByParamsWithNoResults() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	_, err := service.GetServingEnvironmentByParams(of("not-present"), nil)
-	assertion.NotNil(err)
-	assertion.Equal("no serving environments found for name=not-present, externalId=", err.Error())
+	suite.NotNil(err)
+	suite.Equal("no serving environments found for name=not-present, externalId=", err.Error())
 }
 
-func TestGetServingEnvironmentByParamsName(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetServingEnvironmentByParamsName() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	// register a new ServingEnvironment
 	eut := &openapi.ServingEnvironment{
@@ -2015,20 +1909,17 @@ func TestGetServingEnvironmentByParamsName(t *testing.T) {
 	}
 
 	createdEntity, err := service.UpsertServingEnvironment(eut)
-	assertion.Nilf(err, "error creating ServingEnvironment: %v", err)
+	suite.Nilf(err, "error creating ServingEnvironment: %v", err)
 
 	byName, err := service.GetServingEnvironmentByParams(&entityName, nil)
-	assertion.Nilf(err, "error getting ServingEnvironment by name: %v", err)
+	suite.Nilf(err, "error getting ServingEnvironment by name: %v", err)
 
-	assertion.Equalf(*createdEntity.Id, *byName.Id, "the returned entity id should match the retrieved by name")
+	suite.Equalf(*createdEntity.Id, *byName.Id, "the returned entity id should match the retrieved by name")
 }
 
-func TestGetServingEnvironmentByParamsExternalId(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetServingEnvironmentByParamsExternalId() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	// register a new ServingEnvironment
 	eut := &openapi.ServingEnvironment{
@@ -2037,20 +1928,17 @@ func TestGetServingEnvironmentByParamsExternalId(t *testing.T) {
 	}
 
 	createdEntity, err := service.UpsertServingEnvironment(eut)
-	assertion.Nilf(err, "error creating ServingEnvironment: %v", err)
+	suite.Nilf(err, "error creating ServingEnvironment: %v", err)
 
 	byName, err := service.GetServingEnvironmentByParams(nil, &entityExternalId)
-	assertion.Nilf(err, "error getting ServingEnvironment by external id: %v", err)
+	suite.Nilf(err, "error getting ServingEnvironment by external id: %v", err)
 
-	assertion.Equalf(*createdEntity.Id, *byName.Id, "the returned entity id should match the retrieved by name")
+	suite.Equalf(*createdEntity.Id, *byName.Id, "the returned entity id should match the retrieved by name")
 }
 
-func TestGetServingEnvironmentByEmptyParams(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetServingEnvironmentByEmptyParams() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	// register a new ServingEnvironment
 	eut := &openapi.ServingEnvironment{
@@ -2059,19 +1947,16 @@ func TestGetServingEnvironmentByEmptyParams(t *testing.T) {
 	}
 
 	_, err := service.UpsertServingEnvironment(eut)
-	assertion.Nilf(err, "error creating ServingEnvironment: %v", err)
+	suite.Nilf(err, "error creating ServingEnvironment: %v", err)
 
 	_, err = service.GetServingEnvironmentByParams(nil, nil)
-	assertion.NotNil(err)
-	assertion.Equal("invalid parameters call, supply either name or externalId", err.Error())
+	suite.NotNil(err)
+	suite.Equal("invalid parameters call, supply either name or externalId", err.Error())
 }
 
-func TestGetServingEnvironmentsOrderedById(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetServingEnvironmentsOrderedById() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	orderBy := "ID"
 
@@ -2082,51 +1967,48 @@ func TestGetServingEnvironmentsOrderedById(t *testing.T) {
 	}
 
 	_, err := service.UpsertServingEnvironment(eut)
-	assertion.Nilf(err, "error creating ServingEnvironment: %v", err)
+	suite.Nilf(err, "error creating ServingEnvironment: %v", err)
 
 	newName := "Pricingentity2"
 	newExternalId := "myExternalId2"
 	eut.Name = &newName
 	eut.ExternalID = &newExternalId
 	_, err = service.UpsertServingEnvironment(eut)
-	assertion.Nilf(err, "error creating ServingEnvironment: %v", err)
+	suite.Nilf(err, "error creating ServingEnvironment: %v", err)
 
 	newName = "Pricingentity3"
 	newExternalId = "myExternalId3"
 	eut.Name = &newName
 	eut.ExternalID = &newExternalId
 	_, err = service.UpsertServingEnvironment(eut)
-	assertion.Nilf(err, "error creating ServingEnvironment: %v", err)
+	suite.Nilf(err, "error creating ServingEnvironment: %v", err)
 
 	orderedById, err := service.GetServingEnvironments(api.ListOptions{
 		OrderBy:   &orderBy,
 		SortOrder: &ascOrderDirection,
 	})
-	assertion.Nilf(err, "error getting ServingEnvironment: %v", err)
+	suite.Nilf(err, "error getting ServingEnvironment: %v", err)
 
-	assertion.Equal(3, int(orderedById.Size))
+	suite.Equal(3, int(orderedById.Size))
 	for i := 0; i < int(orderedById.Size)-1; i++ {
-		assertion.Less(*orderedById.Items[i].Id, *orderedById.Items[i+1].Id)
+		suite.Less(*orderedById.Items[i].Id, *orderedById.Items[i+1].Id)
 	}
 
 	orderedById, err = service.GetServingEnvironments(api.ListOptions{
 		OrderBy:   &orderBy,
 		SortOrder: &descOrderDirection,
 	})
-	assertion.Nilf(err, "error getting ServingEnvironments: %v", err)
+	suite.Nilf(err, "error getting ServingEnvironments: %v", err)
 
-	assertion.Equal(3, int(orderedById.Size))
+	suite.Equal(3, int(orderedById.Size))
 	for i := 0; i < int(orderedById.Size)-1; i++ {
-		assertion.Greater(*orderedById.Items[i].Id, *orderedById.Items[i+1].Id)
+		suite.Greater(*orderedById.Items[i].Id, *orderedById.Items[i+1].Id)
 	}
 }
 
-func TestGetServingEnvironmentsOrderedByLastUpdate(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetServingEnvironmentsOrderedByLastUpdate() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	orderBy := "LAST_UPDATE_TIME"
 
@@ -2137,56 +2019,53 @@ func TestGetServingEnvironmentsOrderedByLastUpdate(t *testing.T) {
 	}
 
 	firstEntity, err := service.UpsertServingEnvironment(eut)
-	assertion.Nilf(err, "error creating ServingEnvironment: %v", err)
+	suite.Nilf(err, "error creating ServingEnvironment: %v", err)
 
 	newName := "Pricingentity2"
 	newExternalId := "myExternalId2"
 	eut.Name = &newName
 	eut.ExternalID = &newExternalId
 	secondEntity, err := service.UpsertServingEnvironment(eut)
-	assertion.Nilf(err, "error creating ServingEnvironment: %v", err)
+	suite.Nilf(err, "error creating ServingEnvironment: %v", err)
 
 	newName = "Pricingentity3"
 	newExternalId = "myExternalId3"
 	eut.Name = &newName
 	eut.ExternalID = &newExternalId
 	thirdEntity, err := service.UpsertServingEnvironment(eut)
-	assertion.Nilf(err, "error creating ServingEnvironment: %v", err)
+	suite.Nilf(err, "error creating ServingEnvironment: %v", err)
 
 	// update second entity
 	secondEntity.ExternalID = nil
 	_, err = service.UpsertServingEnvironment(secondEntity)
-	assertion.Nilf(err, "error creating ServingEnvironment: %v", err)
+	suite.Nilf(err, "error creating ServingEnvironment: %v", err)
 
 	orderedById, err := service.GetServingEnvironments(api.ListOptions{
 		OrderBy:   &orderBy,
 		SortOrder: &ascOrderDirection,
 	})
-	assertion.Nilf(err, "error getting ServingEnvironments: %v", err)
+	suite.Nilf(err, "error getting ServingEnvironments: %v", err)
 
-	assertion.Equal(3, int(orderedById.Size))
-	assertion.Equal(*firstEntity.Id, *orderedById.Items[0].Id)
-	assertion.Equal(*thirdEntity.Id, *orderedById.Items[1].Id)
-	assertion.Equal(*secondEntity.Id, *orderedById.Items[2].Id)
+	suite.Equal(3, int(orderedById.Size))
+	suite.Equal(*firstEntity.Id, *orderedById.Items[0].Id)
+	suite.Equal(*thirdEntity.Id, *orderedById.Items[1].Id)
+	suite.Equal(*secondEntity.Id, *orderedById.Items[2].Id)
 
 	orderedById, err = service.GetServingEnvironments(api.ListOptions{
 		OrderBy:   &orderBy,
 		SortOrder: &descOrderDirection,
 	})
-	assertion.Nilf(err, "error getting ServingEnvironments: %v", err)
+	suite.Nilf(err, "error getting ServingEnvironments: %v", err)
 
-	assertion.Equal(3, int(orderedById.Size))
-	assertion.Equal(*secondEntity.Id, *orderedById.Items[0].Id)
-	assertion.Equal(*thirdEntity.Id, *orderedById.Items[1].Id)
-	assertion.Equal(*firstEntity.Id, *orderedById.Items[2].Id)
+	suite.Equal(3, int(orderedById.Size))
+	suite.Equal(*secondEntity.Id, *orderedById.Items[0].Id)
+	suite.Equal(*thirdEntity.Id, *orderedById.Items[1].Id)
+	suite.Equal(*firstEntity.Id, *orderedById.Items[2].Id)
 }
 
-func TestGetServingEnvironmentsWithPageSize(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetServingEnvironmentsWithPageSize() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	pageSize := int32(1)
 	pageSize2 := int32(2)
@@ -2200,54 +2079,51 @@ func TestGetServingEnvironmentsWithPageSize(t *testing.T) {
 	}
 
 	firstEntity, err := service.UpsertServingEnvironment(eut)
-	assertion.Nilf(err, "error creating registered entity: %v", err)
+	suite.Nilf(err, "error creating registered entity: %v", err)
 
 	newName := "Pricingentity2"
 	newExternalId := "myExternalId2"
 	eut.Name = &newName
 	eut.ExternalID = &newExternalId
 	secondEntity, err := service.UpsertServingEnvironment(eut)
-	assertion.Nilf(err, "error creating ServingEnvironment: %v", err)
+	suite.Nilf(err, "error creating ServingEnvironment: %v", err)
 
 	newName = "Pricingentity3"
 	newExternalId = "myExternalId3"
 	eut.Name = &newName
 	eut.ExternalID = &newExternalId
 	thirdEntity, err := service.UpsertServingEnvironment(eut)
-	assertion.Nilf(err, "error creating ServingEnvironment: %v", err)
+	suite.Nilf(err, "error creating ServingEnvironment: %v", err)
 
 	truncatedList, err := service.GetServingEnvironments(api.ListOptions{
 		PageSize: &pageSize,
 	})
-	assertion.Nilf(err, "error getting ServingEnvironments: %v", err)
+	suite.Nilf(err, "error getting ServingEnvironments: %v", err)
 
-	assertion.Equal(1, int(truncatedList.Size))
-	assertion.NotEqual("", truncatedList.NextPageToken, "next page token should not be empty")
-	assertion.Equal(*firstEntity.Id, *truncatedList.Items[0].Id)
+	suite.Equal(1, int(truncatedList.Size))
+	suite.NotEqual("", truncatedList.NextPageToken, "next page token should not be empty")
+	suite.Equal(*firstEntity.Id, *truncatedList.Items[0].Id)
 
 	truncatedList, err = service.GetServingEnvironments(api.ListOptions{
 		PageSize:      &pageSize2,
 		NextPageToken: &truncatedList.NextPageToken,
 	})
-	assertion.Nilf(err, "error getting ServingEnvironments: %v", err)
+	suite.Nilf(err, "error getting ServingEnvironments: %v", err)
 
-	assertion.Equal(2, int(truncatedList.Size))
-	assertion.Equal("", truncatedList.NextPageToken, "next page token should be empty as list item returned")
-	assertion.Equal(*secondEntity.Id, *truncatedList.Items[0].Id)
-	assertion.Equal(*thirdEntity.Id, *truncatedList.Items[1].Id)
+	suite.Equal(2, int(truncatedList.Size))
+	suite.Equal("", truncatedList.NextPageToken, "next page token should be empty as list item returned")
+	suite.Equal(*secondEntity.Id, *truncatedList.Items[0].Id)
+	suite.Equal(*thirdEntity.Id, *truncatedList.Items[1].Id)
 }
 
 // INFERENCE SERVICE
 
-func TestCreateInferenceService(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestCreateInferenceService() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	parentResourceId := registerServingEnvironment(assertion, service, nil, nil)
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	parentResourceId := suite.registerServingEnvironment(service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 	runtime := "model-server"
 	state := openapi.INFERENCESERVICESTATE_DEPLOYED
 
@@ -2269,40 +2145,37 @@ func TestCreateInferenceService(t *testing.T) {
 	}
 
 	createdEntity, err := service.UpsertInferenceService(eut)
-	assertion.Nilf(err, "error creating new eut for %s: %v", parentResourceId, err)
+	suite.Nilf(err, "error creating new eut for %s: %v", parentResourceId, err)
 
-	assertion.NotNilf(createdEntity.Id, "created eut should not have nil Id")
+	suite.NotNilf(createdEntity.Id, "created eut should not have nil Id")
 
 	createdEntityId, _ := converter.StringToInt64(createdEntity.Id)
 
-	byId, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	byId, err := suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{
 			*createdEntityId,
 		},
 	})
-	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
-	assertion.Equal(1, len(byId.Contexts), "there should be just one context saved in mlmd")
+	suite.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	suite.Equal(1, len(byId.Contexts), "there should be just one context saved in mlmd")
 
-	assertion.Equal(*createdEntityId, *byId.Contexts[0].Id, "returned id should match the mlmd one")
-	assertion.Equal(fmt.Sprintf("%s:%s", parentResourceId, entityName), *byId.Contexts[0].Name, "saved name should match the provided one")
-	assertion.Equal(entityExternalId2, *byId.Contexts[0].ExternalId, "saved external id should match the provided one")
-	assertion.Equal(customString, byId.Contexts[0].CustomProperties["custom_string_prop"].GetStringValue(), "saved custom_string_prop custom property should match the provided one")
-	assertion.Equal(entityDescription, byId.Contexts[0].Properties["description"].GetStringValue(), "saved description should match the provided one")
-	assertion.Equal(runtime, byId.Contexts[0].Properties["runtime"].GetStringValue(), "saved runtime should match the provided one")
-	assertion.Equal(string(state), byId.Contexts[0].Properties["state"].GetStringValue(), "saved state should match the provided one")
-	assertion.Equalf(*inferenceServiceTypeName, *byId.Contexts[0].Type, "saved context should be of type of %s", *inferenceServiceTypeName)
+	suite.Equal(*createdEntityId, *byId.Contexts[0].Id, "returned id should match the mlmd one")
+	suite.Equal(fmt.Sprintf("%s:%s", parentResourceId, entityName), *byId.Contexts[0].Name, "saved name should match the provided one")
+	suite.Equal(entityExternalId2, *byId.Contexts[0].ExternalId, "saved external id should match the provided one")
+	suite.Equal(customString, byId.Contexts[0].CustomProperties["custom_string_prop"].GetStringValue(), "saved custom_string_prop custom property should match the provided one")
+	suite.Equal(entityDescription, byId.Contexts[0].Properties["description"].GetStringValue(), "saved description should match the provided one")
+	suite.Equal(runtime, byId.Contexts[0].Properties["runtime"].GetStringValue(), "saved runtime should match the provided one")
+	suite.Equal(string(state), byId.Contexts[0].Properties["state"].GetStringValue(), "saved state should match the provided one")
+	suite.Equalf(*inferenceServiceTypeName, *byId.Contexts[0].Type, "saved context should be of type of %s", *inferenceServiceTypeName)
 
-	getAllResp, err := client.GetContexts(context.Background(), &proto.GetContextsRequest{})
-	assertion.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
-	assertion.Equal(3, len(getAllResp.Contexts), "there should be 3 contexts (RegisteredModel, ServingEnvironment, InferenceService) saved in mlmd")
+	getAllResp, err := suite.mlmdClient.GetContexts(context.Background(), &proto.GetContextsRequest{})
+	suite.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
+	suite.Equal(3, len(getAllResp.Contexts), "there should be 3 contexts (RegisteredModel, ServingEnvironment, InferenceService) saved in mlmd")
 }
 
-func TestCreateInferenceServiceFailure(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestCreateInferenceServiceFailure() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
 	eut := &openapi.InferenceService{
 		Name:                 &entityName,
@@ -2319,26 +2192,23 @@ func TestCreateInferenceServiceFailure(t *testing.T) {
 	}
 
 	_, err := service.UpsertInferenceService(eut)
-	assertion.NotNil(err)
-	assertion.Equal("no serving environment found for id 9999", err.Error())
+	suite.NotNil(err)
+	suite.Equal("no serving environment found for id 9999", err.Error())
 
-	parentResourceId := registerServingEnvironment(assertion, service, nil, nil)
+	parentResourceId := suite.registerServingEnvironment(service, nil, nil)
 	eut.ServingEnvironmentId = parentResourceId
 
 	_, err = service.UpsertInferenceService(eut)
-	assertion.NotNil(err)
-	assertion.Equal("no registered model found for id 9998", err.Error())
+	suite.NotNil(err)
+	suite.Equal("no registered model found for id 9998", err.Error())
 }
 
-func TestUpdateInferenceService(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestUpdateInferenceService() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	parentResourceId := registerServingEnvironment(assertion, service, nil, nil)
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	parentResourceId := suite.registerServingEnvironment(service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	eut := &openapi.InferenceService{
 		Name:                 &entityName,
@@ -2356,9 +2226,9 @@ func TestUpdateInferenceService(t *testing.T) {
 	}
 
 	createdEntity, err := service.UpsertInferenceService(eut)
-	assertion.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
 
-	assertion.NotNilf(createdEntity.Id, "created eut should not have nil Id")
+	suite.NotNilf(createdEntity.Id, "created eut should not have nil Id")
 
 	createdEntityId, _ := converter.StringToInt64(createdEntity.Id)
 
@@ -2373,73 +2243,70 @@ func TestUpdateInferenceService(t *testing.T) {
 	}
 
 	updatedEntity, err := service.UpsertInferenceService(createdEntity)
-	assertion.Nilf(err, "error updating new entity for %s: %v", registeredModelId, err)
+	suite.Nilf(err, "error updating new entity for %s: %v", registeredModelId, err)
 
 	updateEntityId, _ := converter.StringToInt64(updatedEntity.Id)
-	assertion.Equal(*createdEntityId, *updateEntityId, "created and updated should have same id")
+	suite.Equal(*createdEntityId, *updateEntityId, "created and updated should have same id")
 
-	byId, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	byId, err := suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{
 			*updateEntityId,
 		},
 	})
-	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
-	assertion.Equal(1, len(byId.Contexts), "there should be 1 context saved in mlmd by id")
+	suite.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	suite.Equal(1, len(byId.Contexts), "there should be 1 context saved in mlmd by id")
 
-	assertion.Equal(*updateEntityId, *byId.Contexts[0].Id, "returned id should match the mlmd one")
-	assertion.Equal(fmt.Sprintf("%s:%s", parentResourceId, *eut.Name), *byId.Contexts[0].Name, "saved name should match the provided one")
-	assertion.Equal(newExternalId, *byId.Contexts[0].ExternalId, "saved external id should match the provided one")
-	assertion.Equal(customString, byId.Contexts[0].CustomProperties["custom_string_prop"].GetStringValue(), "saved custom_string_prop custom property should match the provided one")
-	assertion.Equal(newScore, byId.Contexts[0].CustomProperties["score"].GetDoubleValue(), "saved score custom property should match the provided one")
-	assertion.Equalf(*inferenceServiceTypeName, *byId.Contexts[0].Type, "saved context should be of type of %s", *inferenceServiceTypeName)
+	suite.Equal(*updateEntityId, *byId.Contexts[0].Id, "returned id should match the mlmd one")
+	suite.Equal(fmt.Sprintf("%s:%s", parentResourceId, *eut.Name), *byId.Contexts[0].Name, "saved name should match the provided one")
+	suite.Equal(newExternalId, *byId.Contexts[0].ExternalId, "saved external id should match the provided one")
+	suite.Equal(customString, byId.Contexts[0].CustomProperties["custom_string_prop"].GetStringValue(), "saved custom_string_prop custom property should match the provided one")
+	suite.Equal(newScore, byId.Contexts[0].CustomProperties["score"].GetDoubleValue(), "saved score custom property should match the provided one")
+	suite.Equalf(*inferenceServiceTypeName, *byId.Contexts[0].Type, "saved context should be of type of %s", *inferenceServiceTypeName)
 
-	getAllResp, err := client.GetContexts(context.Background(), &proto.GetContextsRequest{})
-	assertion.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
-	assertion.Equal(3, len(getAllResp.Contexts), "there should be 3 contexts saved in mlmd")
+	getAllResp, err := suite.mlmdClient.GetContexts(context.Background(), &proto.GetContextsRequest{})
+	suite.Nilf(err, "error retrieving all contexts, not related to the test itself: %v", err)
+	suite.Equal(3, len(getAllResp.Contexts), "there should be 3 contexts saved in mlmd")
 
 	// update with nil name
 	newExternalId = "org.my_awesome_entity_@v1"
 	updatedEntity.ExternalID = &newExternalId
 	updatedEntity.Name = nil
 	updatedEntity, err = service.UpsertInferenceService(updatedEntity)
-	assertion.Nilf(err, "error updating new model version for %s: %v", updateEntityId, err)
+	suite.Nilf(err, "error updating new model version for %s: %v", updateEntityId, err)
 
 	updateEntityId, _ = converter.StringToInt64(updatedEntity.Id)
-	assertion.Equal(*createdEntityId, *updateEntityId, "created and updated should have same id")
+	suite.Equal(*createdEntityId, *updateEntityId, "created and updated should have same id")
 
-	byId, err = client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	byId, err = suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{
 			*updateEntityId,
 		},
 	})
-	assertion.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
-	assertion.Equal(1, len(byId.Contexts), "there should be 1 context saved in mlmd by id")
+	suite.Nilf(err, "error retrieving context by type and name, not related to the test itself: %v", err)
+	suite.Equal(1, len(byId.Contexts), "there should be 1 context saved in mlmd by id")
 
-	assertion.Equal(*updateEntityId, *byId.Contexts[0].Id, "returned id should match the mlmd one")
-	assertion.Equal(fmt.Sprintf("%s:%s", parentResourceId, *eut.Name), *byId.Contexts[0].Name, "saved name should match the provided one")
-	assertion.Equal(newExternalId, *byId.Contexts[0].ExternalId, "saved external id should match the provided one")
-	assertion.Equal(customString, byId.Contexts[0].CustomProperties["custom_string_prop"].GetStringValue(), "saved custom_string_prop custom property should match the provided one")
-	assertion.Equal(newScore, byId.Contexts[0].CustomProperties["score"].GetDoubleValue(), "saved score custom property should match the provided one")
-	assertion.Equalf(*inferenceServiceTypeName, *byId.Contexts[0].Type, "saved context should be of type of %s", *inferenceServiceTypeName)
+	suite.Equal(*updateEntityId, *byId.Contexts[0].Id, "returned id should match the mlmd one")
+	suite.Equal(fmt.Sprintf("%s:%s", parentResourceId, *eut.Name), *byId.Contexts[0].Name, "saved name should match the provided one")
+	suite.Equal(newExternalId, *byId.Contexts[0].ExternalId, "saved external id should match the provided one")
+	suite.Equal(customString, byId.Contexts[0].CustomProperties["custom_string_prop"].GetStringValue(), "saved custom_string_prop custom property should match the provided one")
+	suite.Equal(newScore, byId.Contexts[0].CustomProperties["score"].GetDoubleValue(), "saved score custom property should match the provided one")
+	suite.Equalf(*inferenceServiceTypeName, *byId.Contexts[0].Type, "saved context should be of type of %s", *inferenceServiceTypeName)
 
 	// update with empty registeredModelId
 	newExternalId = "org.my_awesome_entity_@v1"
 	prevRegModelId := updatedEntity.RegisteredModelId
 	updatedEntity.RegisteredModelId = ""
 	updatedEntity, err = service.UpsertInferenceService(updatedEntity)
-	assertion.Nil(err)
-	assertion.Equal(prevRegModelId, updatedEntity.RegisteredModelId)
+	suite.Nil(err)
+	suite.Equal(prevRegModelId, updatedEntity.RegisteredModelId)
 }
 
-func TestUpdateInferenceServiceFailure(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestUpdateInferenceServiceFailure() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	parentResourceId := registerServingEnvironment(assertion, service, nil, nil)
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	parentResourceId := suite.registerServingEnvironment(service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	eut := &openapi.InferenceService{
 		Name:                 &entityName,
@@ -2457,9 +2324,9 @@ func TestUpdateInferenceServiceFailure(t *testing.T) {
 	}
 
 	createdEntity, err := service.UpsertInferenceService(eut)
-	assertion.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
 
-	assertion.NotNilf(createdEntity.Id, "created eut should not have nil Id")
+	suite.NotNilf(createdEntity.Id, "created eut should not have nil Id")
 
 	newExternalId := "org.my_awesome_entity@v1"
 	newScore := 0.95
@@ -2474,19 +2341,16 @@ func TestUpdateInferenceServiceFailure(t *testing.T) {
 	wrongId := "9999"
 	createdEntity.Id = &wrongId
 	_, err = service.UpsertInferenceService(createdEntity)
-	assertion.NotNil(err)
-	assertion.Equal(fmt.Sprintf("no InferenceService found for id %s", wrongId), err.Error())
+	suite.NotNil(err)
+	suite.Equal(fmt.Sprintf("no InferenceService found for id %s", wrongId), err.Error())
 }
 
-func TestGetInferenceServiceById(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetInferenceServiceById() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	parentResourceId := registerServingEnvironment(assertion, service, nil, nil)
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	parentResourceId := suite.registerServingEnvironment(service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	state := openapi.INFERENCESERVICESTATE_UNDEPLOYED
 	eut := &openapi.InferenceService{
@@ -2506,38 +2370,35 @@ func TestGetInferenceServiceById(t *testing.T) {
 	}
 
 	createdEntity, err := service.UpsertInferenceService(eut)
-	assertion.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
 
-	assertion.NotNilf(createdEntity.Id, "created eut should not have nil Id")
+	suite.NotNilf(createdEntity.Id, "created eut should not have nil Id")
 	createdEntityId, _ := converter.StringToInt64(createdEntity.Id)
 
 	getById, err := service.GetInferenceServiceById(*createdEntity.Id)
-	assertion.Nilf(err, "error getting model version with id %d", *createdEntityId)
+	suite.Nilf(err, "error getting model version with id %d", *createdEntityId)
 
-	ctxById, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	ctxById, err := suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{
 			*createdEntityId,
 		},
 	})
-	assertion.Nilf(err, "error retrieving context, not related to the test itself: %v", err)
+	suite.Nilf(err, "error retrieving context, not related to the test itself: %v", err)
 
 	ctx := ctxById.Contexts[0]
-	assertion.Equal(*getById.Id, *converter.Int64ToString(ctx.Id), "returned id should match the mlmd context one")
-	assertion.Equal(*eut.Name, *getById.Name, "saved name should match the provided one")
-	assertion.Equal(*eut.ExternalID, *getById.ExternalID, "saved external id should match the provided one")
-	assertion.Equal(*eut.State, *getById.State, "saved state should match the provided one")
-	assertion.Equal(*(*getById.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue, customString, "saved custom_string_prop custom property should match the provided one")
+	suite.Equal(*getById.Id, *converter.Int64ToString(ctx.Id), "returned id should match the mlmd context one")
+	suite.Equal(*eut.Name, *getById.Name, "saved name should match the provided one")
+	suite.Equal(*eut.ExternalID, *getById.ExternalID, "saved external id should match the provided one")
+	suite.Equal(*eut.State, *getById.State, "saved state should match the provided one")
+	suite.Equal(*(*getById.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue, customString, "saved custom_string_prop custom property should match the provided one")
 }
 
-func TestGetRegisteredModelByInferenceServiceId(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetRegisteredModelByInferenceServiceId() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	parentResourceId := registerServingEnvironment(assertion, service, nil, nil)
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	parentResourceId := suite.registerServingEnvironment(service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	eut := &openapi.InferenceService{
 		Name:                 &entityName,
@@ -2554,36 +2415,33 @@ func TestGetRegisteredModelByInferenceServiceId(t *testing.T) {
 		},
 	}
 	createdEntity, err := service.UpsertInferenceService(eut)
-	assertion.Nilf(err, "error creating new eut for %v", parentResourceId)
-	assertion.NotNilf(createdEntity.Id, "created eut should not have nil Id")
+	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.NotNilf(createdEntity.Id, "created eut should not have nil Id")
 	createdEntityId, _ := converter.StringToInt64(createdEntity.Id)
 
 	getRM, err := service.GetRegisteredModelByInferenceService(*createdEntity.Id)
-	assertion.Nilf(err, "error getting using id %d", *createdEntityId)
+	suite.Nilf(err, "error getting using id %d", *createdEntityId)
 
-	assertion.Equal(registeredModelId, *getRM.Id, "returned id should match the original registeredModelId")
+	suite.Equal(registeredModelId, *getRM.Id, "returned id should match the original registeredModelId")
 }
 
-func TestGetModelVersionByInferenceServiceId(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetModelVersionByInferenceServiceId() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	parentResourceId := registerServingEnvironment(assertion, service, nil, nil)
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	parentResourceId := suite.registerServingEnvironment(service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	modelVersion1Name := "v1"
 	modelVersion1 := &openapi.ModelVersion{Name: &modelVersion1Name, Description: &modelVersionDescription}
 	createdVersion1, err := service.UpsertModelVersion(modelVersion1, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 	createdVersion1Id := *createdVersion1.Id
 
 	modelVersion2Name := "v2"
 	modelVersion2 := &openapi.ModelVersion{Name: &modelVersion2Name, Description: &modelVersionDescription}
 	createdVersion2, err := service.UpsertModelVersion(modelVersion2, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 	createdVersion2Id := *createdVersion2.Id
 	// end of data preparation
 
@@ -2603,46 +2461,40 @@ func TestGetModelVersionByInferenceServiceId(t *testing.T) {
 		},
 	}
 	createdEntity, err := service.UpsertInferenceService(eut)
-	assertion.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
 	createdEntityId, _ := converter.StringToInt64(createdEntity.Id)
 
 	getVModel, err := service.GetModelVersionByInferenceService(*createdEntity.Id)
-	assertion.Nilf(err, "error getting using id %d", *createdEntityId)
-	assertion.Equal(createdVersion2Id, *getVModel.Id, "returned id shall be the latest ModelVersion by creation order")
+	suite.Nilf(err, "error getting using id %d", *createdEntityId)
+	suite.Equal(createdVersion2Id, *getVModel.Id, "returned id shall be the latest ModelVersion by creation order")
 
 	// here we used the returned entity (so ID is populated), and we update to specify the "ID of the ModelVersion to serve"
 	createdEntity.ModelVersionId = &createdVersion1Id
 	_, err = service.UpsertInferenceService(createdEntity)
-	assertion.Nilf(err, "error updating eut for %v", parentResourceId)
+	suite.Nilf(err, "error updating eut for %v", parentResourceId)
 
 	getVModel, err = service.GetModelVersionByInferenceService(*createdEntity.Id)
-	assertion.Nilf(err, "error getting using id %d", *createdEntityId)
-	assertion.Equal(createdVersion1Id, *getVModel.Id, "returned id shall be the specified one")
+	suite.Nilf(err, "error getting using id %d", *createdEntityId)
+	suite.Equal(createdVersion1Id, *getVModel.Id, "returned id shall be the specified one")
 }
 
-func TestGetInferenceServiceByParamsWithNoResults(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetInferenceServiceByParamsWithNoResults() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	parentResourceId := registerServingEnvironment(assertion, service, nil, nil)
+	parentResourceId := suite.registerServingEnvironment(service, nil, nil)
 
 	_, err := service.GetInferenceServiceByParams(of("not-present"), &parentResourceId, nil)
-	assertion.NotNil(err)
-	assertion.Equal("no inference services found for name=not-present, parentResourceId=1, externalId=", err.Error())
+	suite.NotNil(err)
+	suite.Equal("no inference services found for name=not-present, parentResourceId=1, externalId=", err.Error())
 }
 
-func TestGetInferenceServiceByParamsName(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetInferenceServiceByParamsName() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	parentResourceId := registerServingEnvironment(assertion, service, nil, nil)
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	parentResourceId := suite.registerServingEnvironment(service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	eut := &openapi.InferenceService{
 		Name:                 &entityName,
@@ -2660,37 +2512,34 @@ func TestGetInferenceServiceByParamsName(t *testing.T) {
 	}
 
 	createdEntity, err := service.UpsertInferenceService(eut)
-	assertion.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
 
-	assertion.NotNilf(createdEntity.Id, "created eut should not have nil Id")
+	suite.NotNilf(createdEntity.Id, "created eut should not have nil Id")
 	createdEntityId, _ := converter.StringToInt64(createdEntity.Id)
 
 	getByName, err := service.GetInferenceServiceByParams(&entityName, &parentResourceId, nil)
-	assertion.Nilf(err, "error getting model version by name %d", *createdEntityId)
+	suite.Nilf(err, "error getting model version by name %d", *createdEntityId)
 
-	ctxById, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	ctxById, err := suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{
 			*createdEntityId,
 		},
 	})
-	assertion.Nilf(err, "error retrieving context, not related to the test itself: %v", err)
+	suite.Nilf(err, "error retrieving context, not related to the test itself: %v", err)
 
 	ctx := ctxById.Contexts[0]
-	assertion.Equal(*converter.Int64ToString(ctx.Id), *getByName.Id, "returned id should match the mlmd context one")
-	assertion.Equal(fmt.Sprintf("%s:%s", parentResourceId, *getByName.Name), *ctx.Name, "saved name should match the provided one")
-	assertion.Equal(*ctx.ExternalId, *getByName.ExternalID, "saved external id should match the provided one")
-	assertion.Equal(ctx.CustomProperties["custom_string_prop"].GetStringValue(), *(*getByName.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue, "saved custom_string_prop custom property should match the provided one")
+	suite.Equal(*converter.Int64ToString(ctx.Id), *getByName.Id, "returned id should match the mlmd context one")
+	suite.Equal(fmt.Sprintf("%s:%s", parentResourceId, *getByName.Name), *ctx.Name, "saved name should match the provided one")
+	suite.Equal(*ctx.ExternalId, *getByName.ExternalID, "saved external id should match the provided one")
+	suite.Equal(ctx.CustomProperties["custom_string_prop"].GetStringValue(), *(*getByName.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue, "saved custom_string_prop custom property should match the provided one")
 }
 
-func TestGetInfernenceServiceByParamsExternalId(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetInfernenceServiceByParamsExternalId() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	parentResourceId := registerServingEnvironment(assertion, service, nil, nil)
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	parentResourceId := suite.registerServingEnvironment(service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	eut := &openapi.InferenceService{
 		Name:                 &entityName,
@@ -2708,37 +2557,34 @@ func TestGetInfernenceServiceByParamsExternalId(t *testing.T) {
 	}
 
 	createdEntity, err := service.UpsertInferenceService(eut)
-	assertion.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
 
-	assertion.NotNilf(createdEntity.Id, "created eut should not have nil Id")
+	suite.NotNilf(createdEntity.Id, "created eut should not have nil Id")
 	createdEntityId, _ := converter.StringToInt64(createdEntity.Id)
 
 	getByExternalId, err := service.GetInferenceServiceByParams(nil, nil, eut.ExternalID)
-	assertion.Nilf(err, "error getting by external id %d", *eut.ExternalID)
+	suite.Nilf(err, "error getting by external id %d", *eut.ExternalID)
 
-	ctxById, err := client.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
+	ctxById, err := suite.mlmdClient.GetContextsByID(context.Background(), &proto.GetContextsByIDRequest{
 		ContextIds: []int64{
 			*createdEntityId,
 		},
 	})
-	assertion.Nilf(err, "error retrieving context, not related to the test itself: %v", err)
+	suite.Nilf(err, "error retrieving context, not related to the test itself: %v", err)
 
 	ctx := ctxById.Contexts[0]
-	assertion.Equal(*converter.Int64ToString(ctx.Id), *getByExternalId.Id, "returned id should match the mlmd context one")
-	assertion.Equal(fmt.Sprintf("%s:%s", parentResourceId, *getByExternalId.Name), *ctx.Name, "saved name should match the provided one")
-	assertion.Equal(*ctx.ExternalId, *getByExternalId.ExternalID, "saved external id should match the provided one")
-	assertion.Equal(ctx.CustomProperties["custom_string_prop"].GetStringValue(), *(*getByExternalId.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue, "saved custom_string_prop custom property should match the provided one")
+	suite.Equal(*converter.Int64ToString(ctx.Id), *getByExternalId.Id, "returned id should match the mlmd context one")
+	suite.Equal(fmt.Sprintf("%s:%s", parentResourceId, *getByExternalId.Name), *ctx.Name, "saved name should match the provided one")
+	suite.Equal(*ctx.ExternalId, *getByExternalId.ExternalID, "saved external id should match the provided one")
+	suite.Equal(ctx.CustomProperties["custom_string_prop"].GetStringValue(), *(*getByExternalId.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue, "saved custom_string_prop custom property should match the provided one")
 }
 
-func TestGetInferenceServiceByEmptyParams(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetInferenceServiceByEmptyParams() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	parentResourceId := registerServingEnvironment(assertion, service, nil, nil)
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	parentResourceId := suite.registerServingEnvironment(service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	eut := &openapi.InferenceService{
 		Name:                 &entityName,
@@ -2756,24 +2602,21 @@ func TestGetInferenceServiceByEmptyParams(t *testing.T) {
 	}
 
 	createdEntity, err := service.UpsertInferenceService(eut)
-	assertion.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
 
-	assertion.NotNilf(createdEntity.Id, "created eut should not have nil Id")
+	suite.NotNilf(createdEntity.Id, "created eut should not have nil Id")
 
 	_, err = service.GetInferenceServiceByParams(nil, nil, nil)
-	assertion.NotNil(err)
-	assertion.Equal("invalid parameters call, supply either (name and parentResourceId), or externalId", err.Error())
+	suite.NotNil(err)
+	suite.Equal("invalid parameters call, supply either (name and parentResourceId), or externalId", err.Error())
 }
 
-func TestGetInferenceServices(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetInferenceServices() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	parentResourceId := registerServingEnvironment(assertion, service, nil, nil)
-	registeredModelId := registerModel(assertion, service, nil, nil)
+	parentResourceId := suite.registerServingEnvironment(service, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
 
 	eut1 := &openapi.InferenceService{
 		Name:                 &entityName,
@@ -2801,17 +2644,17 @@ func TestGetInferenceServices(t *testing.T) {
 	}
 
 	createdEntity1, err := service.UpsertInferenceService(eut1)
-	assertion.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
 
 	createdEntity2, err := service.UpsertInferenceService(eut2)
-	assertion.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
 
 	createdEntity3, err := service.UpsertInferenceService(eut3)
-	assertion.Nilf(err, "error creating new eut for %v", parentResourceId)
+	suite.Nilf(err, "error creating new eut for %v", parentResourceId)
 
 	anotherParentResourceName := "AnotherModel"
 	anotherParentResourceExtId := "org.another"
-	anotherParentResourceId := registerServingEnvironment(assertion, service, &anotherParentResourceName, &anotherParentResourceExtId)
+	anotherParentResourceId := suite.registerServingEnvironment(service, &anotherParentResourceName, &anotherParentResourceExtId)
 
 	anotherName := "v1.0"
 	anotherExtId := "org.another@v1.0"
@@ -2823,23 +2666,23 @@ func TestGetInferenceServices(t *testing.T) {
 	}
 
 	_, err = service.UpsertInferenceService(eutAnother)
-	assertion.Nilf(err, "error creating new model version for %d", anotherParentResourceId)
+	suite.Nilf(err, "error creating new model version for %d", anotherParentResourceId)
 
 	createdId1, _ := converter.StringToInt64(createdEntity1.Id)
 	createdId2, _ := converter.StringToInt64(createdEntity2.Id)
 	createdId3, _ := converter.StringToInt64(createdEntity3.Id)
 
 	getAll, err := service.GetInferenceServices(api.ListOptions{}, nil)
-	assertion.Nilf(err, "error getting all")
-	assertion.Equal(int32(4), getAll.Size, "expected 4 across all parent resources")
+	suite.Nilf(err, "error getting all")
+	suite.Equal(int32(4), getAll.Size, "expected 4 across all parent resources")
 
 	getAllByParentResource, err := service.GetInferenceServices(api.ListOptions{}, &parentResourceId)
-	assertion.Nilf(err, "error getting all")
-	assertion.Equalf(int32(3), getAllByParentResource.Size, "expected 3 for parent resource %d", parentResourceId)
+	suite.Nilf(err, "error getting all")
+	suite.Equalf(int32(3), getAllByParentResource.Size, "expected 3 for parent resource %d", parentResourceId)
 
-	assertion.Equal(*converter.Int64ToString(createdId1), *getAllByParentResource.Items[0].Id)
-	assertion.Equal(*converter.Int64ToString(createdId2), *getAllByParentResource.Items[1].Id)
-	assertion.Equal(*converter.Int64ToString(createdId3), *getAllByParentResource.Items[2].Id)
+	suite.Equal(*converter.Int64ToString(createdId1), *getAllByParentResource.Items[0].Id)
+	suite.Equal(*converter.Int64ToString(createdId2), *getAllByParentResource.Items[1].Id)
+	suite.Equal(*converter.Int64ToString(createdId3), *getAllByParentResource.Items[2].Id)
 
 	// order by last update time, expecting last created as first
 	orderByLastUpdate := "LAST_UPDATE_TIME"
@@ -2847,44 +2690,41 @@ func TestGetInferenceServices(t *testing.T) {
 		OrderBy:   &orderByLastUpdate,
 		SortOrder: &descOrderDirection,
 	}, &parentResourceId)
-	assertion.Nilf(err, "error getting all")
-	assertion.Equalf(int32(3), getAllByParentResource.Size, "expected 3 for parent resource %d", parentResourceId)
+	suite.Nilf(err, "error getting all")
+	suite.Equalf(int32(3), getAllByParentResource.Size, "expected 3 for parent resource %d", parentResourceId)
 
-	assertion.Equal(*converter.Int64ToString(createdId1), *getAllByParentResource.Items[2].Id)
-	assertion.Equal(*converter.Int64ToString(createdId2), *getAllByParentResource.Items[1].Id)
-	assertion.Equal(*converter.Int64ToString(createdId3), *getAllByParentResource.Items[0].Id)
+	suite.Equal(*converter.Int64ToString(createdId1), *getAllByParentResource.Items[2].Id)
+	suite.Equal(*converter.Int64ToString(createdId2), *getAllByParentResource.Items[1].Id)
+	suite.Equal(*converter.Int64ToString(createdId3), *getAllByParentResource.Items[0].Id)
 
 	// update the second entity
 	newExternalId := "updated.org:v2"
 	createdEntity2.ExternalID = &newExternalId
 	createdEntity2, err = service.UpsertInferenceService(createdEntity2)
-	assertion.Nilf(err, "error creating new eut2 for %d", parentResourceId)
+	suite.Nilf(err, "error creating new eut2 for %d", parentResourceId)
 
-	assertion.Equal(newExternalId, *createdEntity2.ExternalID)
+	suite.Equal(newExternalId, *createdEntity2.ExternalID)
 
 	getAllByParentResource, err = service.GetInferenceServices(api.ListOptions{
 		OrderBy:   &orderByLastUpdate,
 		SortOrder: &descOrderDirection,
 	}, &parentResourceId)
-	assertion.Nilf(err, "error getting all")
-	assertion.Equalf(int32(3), getAllByParentResource.Size, "expected 3 for parent resource %d", parentResourceId)
+	suite.Nilf(err, "error getting all")
+	suite.Equalf(int32(3), getAllByParentResource.Size, "expected 3 for parent resource %d", parentResourceId)
 
-	assertion.Equal(*converter.Int64ToString(createdId1), *getAllByParentResource.Items[2].Id)
-	assertion.Equal(*converter.Int64ToString(createdId2), *getAllByParentResource.Items[0].Id)
-	assertion.Equal(*converter.Int64ToString(createdId3), *getAllByParentResource.Items[1].Id)
+	suite.Equal(*converter.Int64ToString(createdId1), *getAllByParentResource.Items[2].Id)
+	suite.Equal(*converter.Int64ToString(createdId2), *getAllByParentResource.Items[0].Id)
+	suite.Equal(*converter.Int64ToString(createdId3), *getAllByParentResource.Items[1].Id)
 }
 
 // SERVE MODEL
 
-func TestCreateServeModel(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestCreateServeModel() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	registeredModelId := registerModel(assertion, service, nil, nil)
-	inferenceServiceId := registerInferenceService(assertion, service, registeredModelId, nil, nil, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
+	inferenceServiceId := suite.registerInferenceService(service, registeredModelId, nil, nil, nil, nil)
 
 	modelVersion := &openapi.ModelVersion{
 		Name:        &modelVersionName,
@@ -2893,7 +2733,7 @@ func TestCreateServeModel(t *testing.T) {
 		Author:      &author,
 	}
 	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 	createdVersionId := *createdVersion.Id
 	createdVersionIdAsInt, _ := converter.StringToInt64(&createdVersionId)
 	// end of data preparation
@@ -2914,46 +2754,43 @@ func TestCreateServeModel(t *testing.T) {
 	}
 
 	createdEntity, err := service.UpsertServeModel(eut, &inferenceServiceId)
-	assertion.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
-	assertion.NotNil(createdEntity.Id, "created id should not be nil")
+	suite.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
+	suite.NotNil(createdEntity.Id, "created id should not be nil")
 
 	state, _ := openapi.NewExecutionStateFromValue(executionState)
-	assertion.Equal(entityName, *createdEntity.Name)
-	assertion.Equal(*state, *createdEntity.LastKnownState)
-	assertion.Equal(createdVersionId, createdEntity.ModelVersionId)
-	assertion.Equal(entityDescription, *createdEntity.Description)
-	assertion.Equal(customString, *(*createdEntity.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue)
+	suite.Equal(entityName, *createdEntity.Name)
+	suite.Equal(*state, *createdEntity.LastKnownState)
+	suite.Equal(createdVersionId, createdEntity.ModelVersionId)
+	suite.Equal(entityDescription, *createdEntity.Description)
+	suite.Equal(customString, *(*createdEntity.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue)
 
 	createdEntityId, _ := converter.StringToInt64(createdEntity.Id)
-	getById, err := client.GetExecutionsByID(context.Background(), &proto.GetExecutionsByIDRequest{
+	getById, err := suite.mlmdClient.GetExecutionsByID(context.Background(), &proto.GetExecutionsByIDRequest{
 		ExecutionIds: []int64{*createdEntityId},
 	})
-	assertion.Nilf(err, "error getting Execution by id %d", createdEntityId)
+	suite.Nilf(err, "error getting Execution by id %d", createdEntityId)
 
-	assertion.Equal(*createdEntityId, *getById.Executions[0].Id)
-	assertion.Equal(fmt.Sprintf("%s:%s", inferenceServiceId, *createdEntity.Name), *getById.Executions[0].Name)
-	assertion.Equal(string(*createdEntity.LastKnownState), getById.Executions[0].LastKnownState.String())
-	assertion.Equal(*createdVersionIdAsInt, getById.Executions[0].Properties["model_version_id"].GetIntValue())
-	assertion.Equal(*createdEntity.Description, getById.Executions[0].Properties["description"].GetStringValue())
-	assertion.Equal(*(*createdEntity.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue, getById.Executions[0].CustomProperties["custom_string_prop"].GetStringValue())
+	suite.Equal(*createdEntityId, *getById.Executions[0].Id)
+	suite.Equal(fmt.Sprintf("%s:%s", inferenceServiceId, *createdEntity.Name), *getById.Executions[0].Name)
+	suite.Equal(string(*createdEntity.LastKnownState), getById.Executions[0].LastKnownState.String())
+	suite.Equal(*createdVersionIdAsInt, getById.Executions[0].Properties["model_version_id"].GetIntValue())
+	suite.Equal(*createdEntity.Description, getById.Executions[0].Properties["description"].GetStringValue())
+	suite.Equal(*(*createdEntity.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue, getById.Executions[0].CustomProperties["custom_string_prop"].GetStringValue())
 
 	inferenceServiceIdAsInt, _ := converter.StringToInt64(&inferenceServiceId)
-	byCtx, _ := client.GetExecutionsByContext(context.Background(), &proto.GetExecutionsByContextRequest{
+	byCtx, _ := suite.mlmdClient.GetExecutionsByContext(context.Background(), &proto.GetExecutionsByContextRequest{
 		ContextId: (*int64)(inferenceServiceIdAsInt),
 	})
-	assertion.Equal(1, len(byCtx.Executions))
-	assertion.Equal(*createdEntityId, *byCtx.Executions[0].Id)
+	suite.Equal(1, len(byCtx.Executions))
+	suite.Equal(*createdEntityId, *byCtx.Executions[0].Id)
 }
 
-func TestCreateServeModelFailure(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestCreateServeModelFailure() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	registeredModelId := registerModel(assertion, service, nil, nil)
-	inferenceServiceId := registerInferenceService(assertion, service, registeredModelId, nil, nil, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
+	inferenceServiceId := suite.registerInferenceService(service, registeredModelId, nil, nil, nil, nil)
 	// end of data preparation
 
 	eut := &openapi.ServeModel{
@@ -2972,23 +2809,20 @@ func TestCreateServeModelFailure(t *testing.T) {
 	}
 
 	_, err := service.UpsertServeModel(eut, nil)
-	assertion.NotNil(err)
-	assertion.Equal("missing parentResourceId, cannot create ServeModel without parent resource InferenceService", err.Error())
+	suite.NotNil(err)
+	suite.Equal("missing parentResourceId, cannot create ServeModel without parent resource InferenceService", err.Error())
 
 	_, err = service.UpsertServeModel(eut, &inferenceServiceId)
-	assertion.NotNil(err)
-	assertion.Equal("no model version found for id 9998", err.Error())
+	suite.NotNil(err)
+	suite.Equal("no model version found for id 9998", err.Error())
 }
 
-func TestUpdateServeModel(t *testing.T) {
-	assertion, conn, client, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestUpdateServeModel() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	registeredModelId := registerModel(assertion, service, nil, nil)
-	inferenceServiceId := registerInferenceService(assertion, service, registeredModelId, nil, nil, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
+	inferenceServiceId := suite.registerInferenceService(service, registeredModelId, nil, nil, nil, nil)
 
 	modelVersion := &openapi.ModelVersion{
 		Name:        &modelVersionName,
@@ -2997,7 +2831,7 @@ func TestUpdateServeModel(t *testing.T) {
 		Author:      &author,
 	}
 	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 	createdVersionId := *createdVersion.Id
 	createdVersionIdAsInt, _ := converter.StringToInt64(&createdVersionId)
 	// end of data preparation
@@ -3018,44 +2852,41 @@ func TestUpdateServeModel(t *testing.T) {
 	}
 
 	createdEntity, err := service.UpsertServeModel(eut, &inferenceServiceId)
-	assertion.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
+	suite.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
 
 	newState := "UNKNOWN"
 	createdEntity.LastKnownState = (*openapi.ExecutionState)(&newState)
 	updatedEntity, err := service.UpsertServeModel(createdEntity, &inferenceServiceId)
-	assertion.Nilf(err, "error updating entity for %d: %v", inferenceServiceId, err)
+	suite.Nilf(err, "error updating entity for %d: %v", inferenceServiceId, err)
 
 	createdEntityId, _ := converter.StringToInt64(createdEntity.Id)
 	updatedEntityId, _ := converter.StringToInt64(updatedEntity.Id)
-	assertion.Equal(createdEntityId, updatedEntityId)
+	suite.Equal(createdEntityId, updatedEntityId)
 
-	getById, err := client.GetExecutionsByID(context.Background(), &proto.GetExecutionsByIDRequest{
+	getById, err := suite.mlmdClient.GetExecutionsByID(context.Background(), &proto.GetExecutionsByIDRequest{
 		ExecutionIds: []int64{*createdEntityId},
 	})
-	assertion.Nilf(err, "error getting by id %d", createdEntityId)
+	suite.Nilf(err, "error getting by id %d", createdEntityId)
 
-	assertion.Equal(*createdEntityId, *getById.Executions[0].Id)
-	assertion.Equal(fmt.Sprintf("%s:%s", inferenceServiceId, *createdEntity.Name), *getById.Executions[0].Name)
-	assertion.Equal(string(newState), getById.Executions[0].LastKnownState.String())
-	assertion.Equal(*createdVersionIdAsInt, getById.Executions[0].Properties["model_version_id"].GetIntValue())
-	assertion.Equal(*(*createdEntity.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue, getById.Executions[0].CustomProperties["custom_string_prop"].GetStringValue())
+	suite.Equal(*createdEntityId, *getById.Executions[0].Id)
+	suite.Equal(fmt.Sprintf("%s:%s", inferenceServiceId, *createdEntity.Name), *getById.Executions[0].Name)
+	suite.Equal(string(newState), getById.Executions[0].LastKnownState.String())
+	suite.Equal(*createdVersionIdAsInt, getById.Executions[0].Properties["model_version_id"].GetIntValue())
+	suite.Equal(*(*createdEntity.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue, getById.Executions[0].CustomProperties["custom_string_prop"].GetStringValue())
 
 	prevModelVersionId := updatedEntity.ModelVersionId
 	updatedEntity.ModelVersionId = ""
 	updatedEntity, err = service.UpsertServeModel(updatedEntity, &inferenceServiceId)
-	assertion.Nilf(err, "error updating entity for %d: %v", inferenceServiceId, err)
-	assertion.Equal(prevModelVersionId, updatedEntity.ModelVersionId)
+	suite.Nilf(err, "error updating entity for %d: %v", inferenceServiceId, err)
+	suite.Equal(prevModelVersionId, updatedEntity.ModelVersionId)
 }
 
-func TestUpdateServeModelFailure(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestUpdateServeModelFailure() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	registeredModelId := registerModel(assertion, service, nil, nil)
-	inferenceServiceId := registerInferenceService(assertion, service, registeredModelId, nil, nil, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
+	inferenceServiceId := suite.registerInferenceService(service, registeredModelId, nil, nil, nil, nil)
 
 	modelVersion := &openapi.ModelVersion{
 		Name:        &modelVersionName,
@@ -3064,7 +2895,7 @@ func TestUpdateServeModelFailure(t *testing.T) {
 		Author:      &author,
 	}
 	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 	createdVersionId := *createdVersion.Id
 	// end of data preparation
 
@@ -3084,30 +2915,27 @@ func TestUpdateServeModelFailure(t *testing.T) {
 	}
 
 	createdEntity, err := service.UpsertServeModel(eut, &inferenceServiceId)
-	assertion.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
-	assertion.NotNil(createdEntity.Id, "created id should not be nil")
+	suite.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
+	suite.NotNil(createdEntity.Id, "created id should not be nil")
 
 	newState := "UNKNOWN"
 	createdEntity.LastKnownState = (*openapi.ExecutionState)(&newState)
 	updatedEntity, err := service.UpsertServeModel(createdEntity, &inferenceServiceId)
-	assertion.Nilf(err, "error updating entity for %d: %v", inferenceServiceId, err)
+	suite.Nilf(err, "error updating entity for %d: %v", inferenceServiceId, err)
 
 	wrongId := "9998"
 	updatedEntity.Id = &wrongId
 	_, err = service.UpsertServeModel(updatedEntity, &inferenceServiceId)
-	assertion.NotNil(err)
-	assertion.Equal(fmt.Sprintf("no ServeModel found for id %s", wrongId), err.Error())
+	suite.NotNil(err)
+	suite.Equal(fmt.Sprintf("no ServeModel found for id %s", wrongId), err.Error())
 }
 
-func TestGetServeModelById(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetServeModelById() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	registeredModelId := registerModel(assertion, service, nil, nil)
-	inferenceServiceId := registerInferenceService(assertion, service, registeredModelId, nil, nil, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
+	inferenceServiceId := suite.registerInferenceService(service, registeredModelId, nil, nil, nil, nil)
 
 	modelVersion := &openapi.ModelVersion{
 		Name:        &modelVersionName,
@@ -3116,7 +2944,7 @@ func TestGetServeModelById(t *testing.T) {
 		Author:      &author,
 	}
 	createdVersion, err := service.UpsertModelVersion(modelVersion, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 	createdVersionId := *createdVersion.Id
 	// end of data preparation
 
@@ -3136,47 +2964,44 @@ func TestGetServeModelById(t *testing.T) {
 	}
 
 	createdEntity, err := service.UpsertServeModel(eut, &inferenceServiceId)
-	assertion.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
+	suite.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
 
 	getById, err := service.GetServeModelById(*createdEntity.Id)
-	assertion.Nilf(err, "error getting entity by id %d", *createdEntity.Id)
+	suite.Nilf(err, "error getting entity by id %d", *createdEntity.Id)
 
 	state, _ := openapi.NewExecutionStateFromValue(executionState)
-	assertion.NotNil(createdEntity.Id, "created artifact id should not be nil")
-	assertion.Equal(entityName, *getById.Name)
-	assertion.Equal(*state, *getById.LastKnownState)
-	assertion.Equal(createdVersionId, getById.ModelVersionId)
-	assertion.Equal(customString, *(*getById.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue)
+	suite.NotNil(createdEntity.Id, "created artifact id should not be nil")
+	suite.Equal(entityName, *getById.Name)
+	suite.Equal(*state, *getById.LastKnownState)
+	suite.Equal(createdVersionId, getById.ModelVersionId)
+	suite.Equal(customString, *(*getById.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue)
 
-	assertion.Equal(*createdEntity, *getById, "artifacts returned during creation and on get by id should be equal")
+	suite.Equal(*createdEntity, *getById, "artifacts returned during creation and on get by id should be equal")
 }
 
-func TestGetServeModels(t *testing.T) {
-	assertion, conn, _, teardown := setup(t)
-	defer teardown(t)
-
+func (suite *CoreTestSuite) TestGetServeModels() {
 	// create mode registry service
-	service := initModelRegistryService(assertion, conn)
+	service := suite.setupModelRegistryService()
 
-	registeredModelId := registerModel(assertion, service, nil, nil)
-	inferenceServiceId := registerInferenceService(assertion, service, registeredModelId, nil, nil, nil, nil)
+	registeredModelId := suite.registerModel(service, nil, nil)
+	inferenceServiceId := suite.registerInferenceService(service, registeredModelId, nil, nil, nil, nil)
 
 	modelVersion1Name := "v1"
 	modelVersion1 := &openapi.ModelVersion{Name: &modelVersion1Name, Description: &modelVersionDescription}
 	createdVersion1, err := service.UpsertModelVersion(modelVersion1, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 	createdVersion1Id := *createdVersion1.Id
 
 	modelVersion2Name := "v2"
 	modelVersion2 := &openapi.ModelVersion{Name: &modelVersion2Name, Description: &modelVersionDescription}
 	createdVersion2, err := service.UpsertModelVersion(modelVersion2, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 	createdVersion2Id := *createdVersion2.Id
 
 	modelVersion3Name := "v3"
 	modelVersion3 := &openapi.ModelVersion{Name: &modelVersion3Name, Description: &modelVersionDescription}
 	createdVersion3, err := service.UpsertModelVersion(modelVersion3, &registeredModelId)
-	assertion.Nilf(err, "error creating new model version for %d", registeredModelId)
+	suite.Nilf(err, "error creating new model version for %d", registeredModelId)
 	createdVersion3Id := *createdVersion3.Id
 	// end of data preparation
 
@@ -3226,33 +3051,33 @@ func TestGetServeModels(t *testing.T) {
 	}
 
 	createdEntity1, err := service.UpsertServeModel(eut1, &inferenceServiceId)
-	assertion.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
+	suite.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
 	createdEntity2, err := service.UpsertServeModel(eut2, &inferenceServiceId)
-	assertion.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
+	suite.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
 	createdEntity3, err := service.UpsertServeModel(eut3, &inferenceServiceId)
-	assertion.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
+	suite.Nilf(err, "error creating new ServeModel for %d", inferenceServiceId)
 
 	createdEntityId1, _ := converter.StringToInt64(createdEntity1.Id)
 	createdEntityId2, _ := converter.StringToInt64(createdEntity2.Id)
 	createdEntityId3, _ := converter.StringToInt64(createdEntity3.Id)
 
 	getAll, err := service.GetServeModels(api.ListOptions{}, nil)
-	assertion.Nilf(err, "error getting all ServeModel")
-	assertion.Equalf(int32(3), getAll.Size, "expected three ServeModel")
+	suite.Nilf(err, "error getting all ServeModel")
+	suite.Equalf(int32(3), getAll.Size, "expected three ServeModel")
 
-	assertion.Equal(*converter.Int64ToString(createdEntityId1), *getAll.Items[0].Id)
-	assertion.Equal(*converter.Int64ToString(createdEntityId2), *getAll.Items[1].Id)
-	assertion.Equal(*converter.Int64ToString(createdEntityId3), *getAll.Items[2].Id)
+	suite.Equal(*converter.Int64ToString(createdEntityId1), *getAll.Items[0].Id)
+	suite.Equal(*converter.Int64ToString(createdEntityId2), *getAll.Items[1].Id)
+	suite.Equal(*converter.Int64ToString(createdEntityId3), *getAll.Items[2].Id)
 
 	orderByLastUpdate := "LAST_UPDATE_TIME"
 	getAllByInferenceService, err := service.GetServeModels(api.ListOptions{
 		OrderBy:   &orderByLastUpdate,
 		SortOrder: &descOrderDirection,
 	}, &inferenceServiceId)
-	assertion.Nilf(err, "error getting all ServeModels for %d", inferenceServiceId)
-	assertion.Equalf(int32(3), getAllByInferenceService.Size, "expected three ServeModels for InferenceServiceId %d", inferenceServiceId)
+	suite.Nilf(err, "error getting all ServeModels for %d", inferenceServiceId)
+	suite.Equalf(int32(3), getAllByInferenceService.Size, "expected three ServeModels for InferenceServiceId %d", inferenceServiceId)
 
-	assertion.Equal(*converter.Int64ToString(createdEntityId1), *getAllByInferenceService.Items[2].Id)
-	assertion.Equal(*converter.Int64ToString(createdEntityId2), *getAllByInferenceService.Items[1].Id)
-	assertion.Equal(*converter.Int64ToString(createdEntityId3), *getAllByInferenceService.Items[0].Id)
+	suite.Equal(*converter.Int64ToString(createdEntityId1), *getAllByInferenceService.Items[2].Id)
+	suite.Equal(*converter.Int64ToString(createdEntityId2), *getAllByInferenceService.Items[1].Id)
+	suite.Equal(*converter.Int64ToString(createdEntityId3), *getAllByInferenceService.Items[0].Id)
 }

--- a/pkg/core/core_test.go
+++ b/pkg/core/core_test.go
@@ -63,7 +63,7 @@ func TestRunCoreTestSuite(t *testing.T) {
 	suite.Run(t, &coreTestSuite)
 }
 
-// befor each test case
+// before each test case
 func (suite *CoreTestSuite) SetupTest() {
 	// initialize test variable before each test
 	ascOrderDirection = "ASC"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/opendatahub-io/model-registry/issues/212

## Description
<!--- Describe your changes in detail -->

Refactor the core testing (file `core_test`) to make use of a single MLMD TestContainer, thanks to this improvement we should reduce the overhead caused by starting up and tearding down the test container itself.

From a technical point of view I made use of testify test `Suite` object, in this way `before/after each` methods are much more explicit and they do not have to be called by every test method.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```bash
make test
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
