### PR TITLE
Enhance go API for serving

### DIFF
--- a/internal/server/openapi/api_model_registry_service_service.go
+++ b/internal/server/openapi/api_model_registry_service_service.go
@@ -236,7 +236,7 @@ func (s *ModelRegistryServiceAPIService) GetEnvironmentInferenceServices(ctx con
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetInferenceServices(listOpts, &servingenvironmentId)
+	result, err := s.coreApi.GetInferenceServices(listOpts, &servingenvironmentId, nil)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -299,7 +299,7 @@ func (s *ModelRegistryServiceAPIService) GetInferenceServices(ctx context.Contex
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
-	result, err := s.coreApi.GetInferenceServices(listOpts, nil)
+	result, err := s.coreApi.GetInferenceServices(listOpts, nil, nil)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -57,6 +57,9 @@ type ModelRegistryApi interface {
 	// GetModelArtifactById retrieve ModelArtifact by id
 	GetModelArtifactById(id string) (*openapi.ModelArtifact, error)
 
+	// GetModelArtifactByInferenceService retrieve a ModelArtifact by inference service id
+	GetModelArtifactByInferenceService(inferenceServiceId string) (*openapi.ModelArtifact, error)
+
 	// GetModelArtifactByParams find ModelArtifact instances that match the provided optional params
 	GetModelArtifactByParams(artifactName *string, modelVersionId *string, externalId *string) (*openapi.ModelArtifact, error)
 
@@ -95,7 +98,8 @@ type ModelRegistryApi interface {
 
 	// GetInferenceServices return all InferenceService properly ordered and sized based on listOptions param
 	// if servingEnvironmentId is provided, return all InferenceService instances belonging to a specific ServingEnvironment
-	GetInferenceServices(listOptions ListOptions, servingEnvironmentId *string) (*openapi.InferenceServiceList, error)
+	// if runtime is provided, filter those InferenceService having that runtime
+	GetInferenceServices(listOptions ListOptions, servingEnvironmentId *string, runtime *string) (*openapi.InferenceServiceList, error)
 
 	// SERVE MODEL
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/opendatahub-io/model-registry/issues/216

## Description
<!--- Describe your changes in detail -->

Update the Go api as follows:
* Add `GetModelArtifactByInferenceService(inferenceServiceId string)`: retrieves the specific `ModelArtifact` by inference service id
* Update `GetInferenceServices(listOptions ListOptions, servingEnvironmentId *string, runtime *string)`: filters inference service by `runtime` in addition to the already existing `servingEnvironmentId`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```bash
make test
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
