### PR TITLE
Improve err mgmt when providing wrong entity

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,0 +1,11 @@
+package constants
+
+// MLMD type names
+const (
+	RegisteredModelTypeName    = "odh.RegisteredModel"
+	ModelVersionTypeName       = "odh.ModelVersion"
+	ModelArtifactTypeName      = "odh.ModelArtifact"
+	ServingEnvironmentTypeName = "odh.ServingEnvironment"
+	InferenceServiceTypeName   = "odh.InferenceService"
+	ServeModelTypeName         = "odh.ServeModel"
+)

--- a/internal/converter/mlmd_converter_util_test.go
+++ b/internal/converter/mlmd_converter_util_test.go
@@ -624,21 +624,18 @@ func TestMapInferenceServiceProperties(t *testing.T) {
 	assertion.Equal(int64(3), props["serving_environment_id"].GetIntValue())
 
 	// serving and model id must be provided and must be a valid numeric id
-	props, err = MapInferenceServiceProperties(&openapi.InferenceService{})
+	_, err = MapInferenceServiceProperties(&openapi.InferenceService{})
 	assertion.NotNil(err)
 	assertion.Equal("missing required RegisteredModelId field", err.Error())
-	assertion.Equal(0, len(props))
 
-	props, err = MapInferenceServiceProperties(&openapi.InferenceService{RegisteredModelId: "1"})
+	_, err = MapInferenceServiceProperties(&openapi.InferenceService{RegisteredModelId: "1"})
 	assertion.NotNil(err)
 	assertion.Equal("missing required ServingEnvironmentId field", err.Error())
-	assertion.Equal(0, len(props))
 
 	// invalid int
-	props, err = MapInferenceServiceProperties(&openapi.InferenceService{RegisteredModelId: "aa"})
+	_, err = MapInferenceServiceProperties(&openapi.InferenceService{RegisteredModelId: "aa"})
 	assertion.NotNil(err)
 	assertion.Equal("invalid numeric string: strconv.Atoi: parsing \"aa\": invalid syntax", err.Error())
-	assertion.Equal(0, len(props))
 }
 
 func TestMapServeModelType(t *testing.T) {
@@ -662,16 +659,14 @@ func TestMapServeModelProperties(t *testing.T) {
 	assertion.Equal(int64(1), props["model_version_id"].GetIntValue())
 
 	// model version id must be provided
-	props, err = MapServeModelProperties(&openapi.ServeModel{})
+	_, err = MapServeModelProperties(&openapi.ServeModel{})
 	assertion.NotNil(err)
 	assertion.Equal("missing required ModelVersionId field", err.Error())
-	assertion.Equal(0, len(props))
 
 	// model version id must be a valid numeric
-	props, err = MapServeModelProperties(&openapi.ServeModel{ModelVersionId: "bb"})
+	_, err = MapServeModelProperties(&openapi.ServeModel{ModelVersionId: "bb"})
 	assertion.NotNil(err)
 	assertion.Equal("invalid numeric string: strconv.Atoi: parsing \"bb\": invalid syntax", err.Error())
-	assertion.Equal(0, len(props))
 }
 
 func TestMapServingEnvironmentProperties(t *testing.T) {

--- a/internal/converter/mlmd_converter_util_test.go
+++ b/internal/converter/mlmd_converter_util_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/opendatahub-io/model-registry/internal/constants"
 	"github.com/opendatahub-io/model-registry/internal/ml_metadata/proto"
 	"github.com/opendatahub-io/model-registry/pkg/openapi"
 	"github.com/stretchr/testify/assert"
@@ -207,7 +208,7 @@ func TestMapRegisteredModelType(t *testing.T) {
 
 	typeName := MapRegisteredModelType(&openapi.RegisteredModel{})
 	assertion.NotNil(typeName)
-	assertion.Equal(RegisteredModelTypeName, *typeName)
+	assertion.Equal(constants.RegisteredModelTypeName, *typeName)
 }
 
 func TestMapModelVersionProperties(t *testing.T) {
@@ -235,7 +236,7 @@ func TestMapModelVersionType(t *testing.T) {
 
 	typeName := MapModelVersionType(&openapi.ModelVersion{})
 	assertion.NotNil(typeName)
-	assertion.Equal(ModelVersionTypeName, *typeName)
+	assertion.Equal(constants.ModelVersionTypeName, *typeName)
 }
 
 func TestMapModelVersionName(t *testing.T) {
@@ -286,7 +287,7 @@ func TestMapModelArtifactType(t *testing.T) {
 
 	typeName := MapModelArtifactType(&openapi.ModelArtifact{})
 	assertion.NotNil(typeName)
-	assertion.Equal(ModelArtifactTypeName, *typeName)
+	assertion.Equal(constants.ModelArtifactTypeName, *typeName)
 }
 
 func TestMapModelArtifactName(t *testing.T) {
@@ -517,7 +518,7 @@ func TestMapArtifactType(t *testing.T) {
 	assertion := setup(t)
 
 	artifactType, err := MapArtifactType(&proto.Artifact{
-		Type: of(ModelArtifactTypeName),
+		Type: of(constants.ModelArtifactTypeName),
 	})
 	assertion.Nil(err)
 	assertion.Equal("model-artifact", artifactType)
@@ -593,7 +594,7 @@ func TestMapServingEnvironmentType(t *testing.T) {
 
 	typeName := MapServingEnvironmentType(&openapi.ServingEnvironment{})
 	assertion.NotNil(typeName)
-	assertion.Equal(ServingEnvironmentTypeName, *typeName)
+	assertion.Equal(constants.ServingEnvironmentTypeName, *typeName)
 }
 
 func TestMapInferenceServiceType(t *testing.T) {
@@ -601,7 +602,7 @@ func TestMapInferenceServiceType(t *testing.T) {
 
 	typeName := MapInferenceServiceType(&openapi.InferenceService{})
 	assertion.NotNil(typeName)
-	assertion.Equal(InferenceServiceTypeName, *typeName)
+	assertion.Equal(constants.InferenceServiceTypeName, *typeName)
 }
 
 func TestMapInferenceServiceProperties(t *testing.T) {
@@ -625,6 +626,18 @@ func TestMapInferenceServiceProperties(t *testing.T) {
 	// serving and model id must be provided and must be a valid numeric id
 	props, err = MapInferenceServiceProperties(&openapi.InferenceService{})
 	assertion.NotNil(err)
+	assertion.Equal("missing required RegisteredModelId field", err.Error())
+	assertion.Equal(0, len(props))
+
+	props, err = MapInferenceServiceProperties(&openapi.InferenceService{RegisteredModelId: "1"})
+	assertion.NotNil(err)
+	assertion.Equal("missing required ServingEnvironmentId field", err.Error())
+	assertion.Equal(0, len(props))
+
+	// invalid int
+	props, err = MapInferenceServiceProperties(&openapi.InferenceService{RegisteredModelId: "aa"})
+	assertion.NotNil(err)
+	assertion.Equal("invalid numeric string: strconv.Atoi: parsing \"aa\": invalid syntax", err.Error())
 	assertion.Equal(0, len(props))
 }
 
@@ -633,7 +646,7 @@ func TestMapServeModelType(t *testing.T) {
 
 	typeName := MapServeModelType(&openapi.ServeModel{})
 	assertion.NotNil(typeName)
-	assertion.Equal(ServeModelTypeName, *typeName)
+	assertion.Equal(constants.ServeModelTypeName, *typeName)
 }
 
 func TestMapServeModelProperties(t *testing.T) {
@@ -648,9 +661,16 @@ func TestMapServeModelProperties(t *testing.T) {
 	assertion.Equal("my custom description", props["description"].GetStringValue())
 	assertion.Equal(int64(1), props["model_version_id"].GetIntValue())
 
-	// serving and model id must be provided and must be a valid numeric id
+	// model version id must be provided
 	props, err = MapServeModelProperties(&openapi.ServeModel{})
 	assertion.NotNil(err)
+	assertion.Equal("missing required ModelVersionId field", err.Error())
+	assertion.Equal(0, len(props))
+
+	// model version id must be a valid numeric
+	props, err = MapServeModelProperties(&openapi.ServeModel{ModelVersionId: "bb"})
+	assertion.NotNil(err)
+	assertion.Equal("invalid numeric string: strconv.Atoi: parsing \"bb\": invalid syntax", err.Error())
 	assertion.Equal(0, len(props))
 }
 

--- a/internal/converter/mlmd_openapi_converter_util.go
+++ b/internal/converter/mlmd_openapi_converter_util.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/opendatahub-io/model-registry/internal/constants"
 	"github.com/opendatahub-io/model-registry/internal/ml_metadata/proto"
 	"github.com/opendatahub-io/model-registry/pkg/openapi"
 )
@@ -82,7 +83,7 @@ func MapPropertyAuthor(properties map[string]*proto.Value) *string {
 // MODEL ARTIFACT
 
 func MapArtifactType(source *proto.Artifact) (string, error) {
-	if source.Type != nil && *source.Type == ModelArtifactTypeName {
+	if source.Type != nil && *source.Type == constants.ModelArtifactTypeName {
 		return "model-artifact", nil
 	}
 	return "", fmt.Errorf("invalid artifact type found: %v", source.Type)

--- a/internal/converter/openapi_mlmd_converter.go
+++ b/internal/converter/openapi_mlmd_converter.go
@@ -5,15 +5,6 @@ import (
 	"github.com/opendatahub-io/model-registry/pkg/openapi"
 )
 
-const (
-	RegisteredModelTypeName    = "odh.RegisteredModel"
-	ModelVersionTypeName       = "odh.ModelVersion"
-	ModelArtifactTypeName      = "odh.ModelArtifact"
-	ServingEnvironmentTypeName = "odh.ServingEnvironment"
-	InferenceServiceTypeName   = "odh.InferenceService"
-	ServeModelTypeName         = "odh.ServeModel"
-)
-
 type OpenAPIModelWrapper[
 	M openapi.RegisteredModel |
 		openapi.ModelVersion |

--- a/internal/converter/openapi_mlmd_converter_util.go
+++ b/internal/converter/openapi_mlmd_converter_util.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/google/uuid"
+	"github.com/opendatahub-io/model-registry/internal/constants"
 	"github.com/opendatahub-io/model-registry/internal/ml_metadata/proto"
 	"github.com/opendatahub-io/model-registry/pkg/openapi"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -20,7 +21,7 @@ func StringToInt64(id *string) (*int64, error) {
 
 	idAsInt, err := strconv.Atoi(*id)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid numeric string: %v", err)
 	}
 
 	idInt64 := int64(idAsInt)
@@ -143,7 +144,7 @@ func MapRegisteredModelProperties(source *openapi.RegisteredModel) (map[string]*
 
 // MapRegisteredModelType return RegisteredModel corresponding MLMD context type
 func MapRegisteredModelType(_ *openapi.RegisteredModel) *string {
-	return of(RegisteredModelTypeName)
+	return of(constants.RegisteredModelTypeName)
 }
 
 // MODEL VERSION
@@ -193,7 +194,7 @@ func MapModelVersionProperties(source *OpenAPIModelWrapper[openapi.ModelVersion]
 
 // MapModelVersionType return ModelVersion corresponding MLMD context type
 func MapModelVersionType(_ *openapi.ModelVersion) *string {
-	return of(ModelVersionTypeName)
+	return of(constants.ModelVersionTypeName)
 }
 
 // MapModelVersionName maps the user-provided name into MLMD one, i.e., prefixing it with
@@ -256,7 +257,7 @@ func MapModelArtifactProperties(source *openapi.ModelArtifact) (map[string]*prot
 
 // MapModelArtifactType return ModelArtifact corresponding MLMD context type
 func MapModelArtifactType(_ *openapi.ModelArtifact) *string {
-	return of(ModelArtifactTypeName)
+	return of(constants.ModelArtifactTypeName)
 }
 
 // MapModelArtifactName maps the user-provided name into MLMD one, i.e., prefixing it with
@@ -290,7 +291,7 @@ func MapOpenAPIModelArtifactState(source *openapi.ArtifactState) (*proto.Artifac
 
 // MapServingEnvironmentType return ServingEnvironment corresponding MLMD context type
 func MapServingEnvironmentType(_ *openapi.ServingEnvironment) *string {
-	return of(ServingEnvironmentTypeName)
+	return of(constants.ServingEnvironmentTypeName)
 }
 
 // MapServingEnvironmentProperties maps ServingEnvironment fields to specific MLMD properties
@@ -312,7 +313,7 @@ func MapServingEnvironmentProperties(source *openapi.ServingEnvironment) (map[st
 
 // MapInferenceServiceType return InferenceService corresponding MLMD context type
 func MapInferenceServiceType(_ *openapi.InferenceService) *string {
-	return of(InferenceServiceTypeName)
+	return of(constants.InferenceServiceTypeName)
 }
 
 // MapInferenceServiceProperties maps InferenceService fields to specific MLMD properties
@@ -343,24 +344,32 @@ func MapInferenceServiceProperties(source *openapi.InferenceService) (map[string
 			}
 		}
 
-		registeredModelId, err := StringToInt64(&source.RegisteredModelId)
-		if err != nil {
-			return nil, err
-		}
-		props["registered_model_id"] = &proto.Value{
-			Value: &proto.Value_IntValue{
-				IntValue: *registeredModelId,
-			},
+		if source.RegisteredModelId != "" {
+			registeredModelId, err := StringToInt64(&source.RegisteredModelId)
+			if err != nil {
+				return nil, err
+			}
+			props["registered_model_id"] = &proto.Value{
+				Value: &proto.Value_IntValue{
+					IntValue: *registeredModelId,
+				},
+			}
+		} else {
+			return nil, fmt.Errorf("missing required RegisteredModelId field")
 		}
 
-		servingEnvironmentId, err := StringToInt64(&source.ServingEnvironmentId)
-		if err != nil {
-			return nil, err
-		}
-		props["serving_environment_id"] = &proto.Value{
-			Value: &proto.Value_IntValue{
-				IntValue: *servingEnvironmentId,
-			},
+		if source.ServingEnvironmentId != "" {
+			servingEnvironmentId, err := StringToInt64(&source.ServingEnvironmentId)
+			if err != nil {
+				return nil, err
+			}
+			props["serving_environment_id"] = &proto.Value{
+				Value: &proto.Value_IntValue{
+					IntValue: *servingEnvironmentId,
+				},
+			}
+		} else {
+			return nil, fmt.Errorf("missing required ServingEnvironmentId field")
 		}
 
 		if source.ModelVersionId != nil {
@@ -390,7 +399,7 @@ func MapInferenceServiceName(source *OpenAPIModelWrapper[openapi.InferenceServic
 
 // MapServeModelType return ServeModel corresponding MLMD context type
 func MapServeModelType(_ *openapi.ServeModel) *string {
-	return of(ServeModelTypeName)
+	return of(constants.ServeModelTypeName)
 }
 
 // MapServeModelProperties maps ServeModel fields to specific MLMD properties
@@ -405,16 +414,19 @@ func MapServeModelProperties(source *openapi.ServeModel) (map[string]*proto.Valu
 			}
 		}
 
-		modelVersionId, err := StringToInt64(&source.ModelVersionId)
-		if err != nil {
-			return nil, err
+		if source.ModelVersionId != "" {
+			modelVersionId, err := StringToInt64(&source.ModelVersionId)
+			if err != nil {
+				return nil, err
+			}
+			props["model_version_id"] = &proto.Value{
+				Value: &proto.Value_IntValue{
+					IntValue: *modelVersionId,
+				},
+			}
+		} else {
+			return nil, fmt.Errorf("missing required ModelVersionId field")
 		}
-		props["model_version_id"] = &proto.Value{
-			Value: &proto.Value_IntValue{
-				IntValue: *modelVersionId,
-			},
-		}
-
 	}
 	return props, nil
 }

--- a/internal/mapper/mapper_test.go
+++ b/internal/mapper/mapper_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/opendatahub-io/model-registry/internal/constants"
 	"github.com/opendatahub-io/model-registry/internal/ml_metadata/proto"
+	"github.com/opendatahub-io/model-registry/pkg/openapi"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,21 +20,120 @@ const (
 	serveModelTypeId         = int64(6)
 )
 
+var typesMap = map[string]int64{
+	constants.RegisteredModelTypeName:    registeredModelTypeId,
+	constants.ModelVersionTypeName:       modelVersionTypeId,
+	constants.ModelArtifactTypeName:      modelArtifactTypeId,
+	constants.ServingEnvironmentTypeName: servingEnvironmentTypeId,
+	constants.InferenceServiceTypeName:   inferenceServiceTypeId,
+	constants.ServeModelTypeName:         serveModelTypeId,
+}
+
 func setup(t *testing.T) (*assert.Assertions, *Mapper) {
 	return assert.New(t), NewMapper(
-		registeredModelTypeId,
-		modelVersionTypeId,
-		modelArtifactTypeId,
-		servingEnvironmentTypeId,
-		inferenceServiceTypeId,
-		serveModelTypeId,
+		typesMap,
 	)
+}
+
+func TestMapFromRegisteredModel(t *testing.T) {
+	assertion, m := setup(t)
+
+	ctx, err := m.MapFromRegisteredModel(&openapi.RegisteredModel{Name: of("ModelName")})
+	assertion.Nil(err)
+	assertion.Equal("ModelName", ctx.GetName())
+	assertion.Equal(registeredModelTypeId, ctx.GetTypeId())
+}
+
+func TestMapFromModelVersion(t *testing.T) {
+	assertion, m := setup(t)
+
+	ctx, err := m.MapFromModelVersion(&openapi.ModelVersion{Name: of("v1")}, "1", of("ModelName"))
+	assertion.Nil(err)
+	assertion.Equal("1:v1", ctx.GetName())
+	assertion.Equal(modelVersionTypeId, ctx.GetTypeId())
+}
+
+func TestMapFromModelArtifact(t *testing.T) {
+	assertion, m := setup(t)
+
+	ctx, err := m.MapFromModelArtifact(&openapi.ModelArtifact{Name: of("ModelArtifact")}, of("2"))
+	assertion.Nil(err)
+	assertion.Equal("2:ModelArtifact", ctx.GetName())
+	assertion.Equal(modelArtifactTypeId, ctx.GetTypeId())
+}
+
+func TestMapFromModelArtifacts(t *testing.T) {
+	assertion, m := setup(t)
+
+	ctxList, err := m.MapFromModelArtifacts([]openapi.ModelArtifact{{Name: of("ModelArtifact1")}, {Name: of("ModelArtifact2")}}, of("2"))
+	assertion.Nil(err)
+	assertion.Equal(2, len(ctxList))
+	assertion.Equal("2:ModelArtifact1", ctxList[0].GetName())
+	assertion.Equal("2:ModelArtifact2", ctxList[1].GetName())
+	assertion.Equal(modelArtifactTypeId, ctxList[0].GetTypeId())
+	assertion.Equal(modelArtifactTypeId, ctxList[1].GetTypeId())
+}
+
+func TestMapFromModelArtifactsEmpty(t *testing.T) {
+	assertion, m := setup(t)
+
+	ctxList, err := m.MapFromModelArtifacts([]openapi.ModelArtifact{}, of("2"))
+	assertion.Nil(err)
+	assertion.Equal(0, len(ctxList))
+
+	ctxList, err = m.MapFromModelArtifacts(nil, nil)
+	assertion.Nil(err)
+	assertion.Equal(0, len(ctxList))
+}
+
+func TestMapFromServingEnvironment(t *testing.T) {
+	assertion, m := setup(t)
+
+	ctx, err := m.MapFromServingEnvironment(&openapi.ServingEnvironment{Name: of("Env")})
+	assertion.Nil(err)
+	assertion.Equal("Env", ctx.GetName())
+	assertion.Equal(servingEnvironmentTypeId, ctx.GetTypeId())
+}
+
+func TestMapFromInferenceService(t *testing.T) {
+	assertion, m := setup(t)
+
+	ctx, err := m.MapFromInferenceService(&openapi.InferenceService{Name: of("IS"), ServingEnvironmentId: "5", RegisteredModelId: "1"}, "5")
+	assertion.Nil(err)
+	assertion.Equal("5:IS", ctx.GetName())
+	assertion.Equal(inferenceServiceTypeId, ctx.GetTypeId())
+}
+
+func TestMapFromInferenceServiceMissingRequiredIds(t *testing.T) {
+	assertion, m := setup(t)
+
+	_, err := m.MapFromInferenceService(&openapi.InferenceService{Name: of("IS")}, "5")
+	assertion.NotNil(err)
+	assertion.Equal("error setting field Properties: missing required RegisteredModelId field", err.Error())
+}
+
+func TestMapFromServeModel(t *testing.T) {
+	assertion, m := setup(t)
+
+	ctx, err := m.MapFromServeModel(&openapi.ServeModel{Name: of("Serve"), ModelVersionId: "1"}, "10")
+	assertion.Nil(err)
+	assertion.Equal("10:Serve", ctx.GetName())
+	assertion.Equal(serveModelTypeId, ctx.GetTypeId())
+}
+
+func TestMapFromServeModelMissingRequiredId(t *testing.T) {
+	assertion, m := setup(t)
+
+	_, err := m.MapFromServeModel(&openapi.ServeModel{Name: of("Serve")}, "10")
+	assertion.NotNil(err)
+	assertion.Equal("error setting field Properties: missing required ModelVersionId field", err.Error())
 }
 
 func TestMapToRegisteredModel(t *testing.T) {
 	assertion, m := setup(t)
 	_, err := m.MapToRegisteredModel(&proto.Context{
 		TypeId: of(registeredModelTypeId),
+		Type:   of(constants.RegisteredModelTypeName),
 	})
 	assertion.Nil(err)
 }
@@ -41,15 +142,17 @@ func TestMapToRegisteredModelInvalid(t *testing.T) {
 	assertion, m := setup(t)
 	_, err := m.MapToRegisteredModel(&proto.Context{
 		TypeId: of(invalidTypeId),
+		Type:   of("odh.OtherEntity"),
 	})
 	assertion.NotNil(err)
-	assertion.Equal(fmt.Sprintf("invalid TypeId, expected %d but received %d", registeredModelTypeId, invalidTypeId), err.Error())
+	assertion.Equal(fmt.Sprintf("invalid entity: expected %s but received odh.OtherEntity, please check the provided id", constants.RegisteredModelTypeName), err.Error())
 }
 
 func TestMapToModelVersion(t *testing.T) {
 	assertion, m := setup(t)
 	_, err := m.MapToModelVersion(&proto.Context{
 		TypeId: of(modelVersionTypeId),
+		Type:   of(constants.ModelVersionTypeName),
 	})
 	assertion.Nil(err)
 }
@@ -58,16 +161,17 @@ func TestMapToModelVersionInvalid(t *testing.T) {
 	assertion, m := setup(t)
 	_, err := m.MapToModelVersion(&proto.Context{
 		TypeId: of(invalidTypeId),
+		Type:   of("odh.OtherEntity"),
 	})
 	assertion.NotNil(err)
-	assertion.Equal(fmt.Sprintf("invalid TypeId, expected %d but received %d", modelVersionTypeId, invalidTypeId), err.Error())
+	assertion.Equal(fmt.Sprintf("invalid entity: expected %s but received odh.OtherEntity, please check the provided id", constants.ModelVersionTypeName), err.Error())
 }
 
 func TestMapToModelArtifact(t *testing.T) {
 	assertion, m := setup(t)
 	_, err := m.MapToModelArtifact(&proto.Artifact{
 		TypeId: of(modelArtifactTypeId),
-		Type:   of("odh.ModelArtifact"),
+		Type:   of(constants.ModelArtifactTypeName),
 	})
 	assertion.Nil(err)
 }
@@ -85,15 +189,17 @@ func TestMapToModelArtifactInvalid(t *testing.T) {
 	assertion, m := setup(t)
 	_, err := m.MapToModelArtifact(&proto.Artifact{
 		TypeId: of(invalidTypeId),
+		Type:   of("odh.OtherEntity"),
 	})
 	assertion.NotNil(err)
-	assertion.Equal(fmt.Sprintf("invalid TypeId, expected %d but received %d", modelArtifactTypeId, invalidTypeId), err.Error())
+	assertion.Equal(fmt.Sprintf("invalid entity: expected %s but received odh.OtherEntity, please check the provided id", constants.ModelArtifactTypeName), err.Error())
 }
 
 func TestMapToServingEnvironment(t *testing.T) {
 	assertion, m := setup(t)
 	_, err := m.MapToServingEnvironment(&proto.Context{
 		TypeId: of(servingEnvironmentTypeId),
+		Type:   of(constants.ServingEnvironmentTypeName),
 	})
 	assertion.Nil(err)
 }
@@ -102,15 +208,17 @@ func TestMapToServingEnvironmentInvalid(t *testing.T) {
 	assertion, m := setup(t)
 	_, err := m.MapToServingEnvironment(&proto.Context{
 		TypeId: of(invalidTypeId),
+		Type:   of("odh.OtherEntity"),
 	})
 	assertion.NotNil(err)
-	assertion.Equal(fmt.Sprintf("invalid TypeId, expected %d but received %d", servingEnvironmentTypeId, invalidTypeId), err.Error())
+	assertion.Equal(fmt.Sprintf("invalid entity: expected %s but received odh.OtherEntity, please check the provided id", constants.ServingEnvironmentTypeName), err.Error())
 }
 
 func TestMapToInferenceService(t *testing.T) {
 	assertion, m := setup(t)
 	_, err := m.MapToInferenceService(&proto.Context{
 		TypeId: of(inferenceServiceTypeId),
+		Type:   of(constants.InferenceServiceTypeName),
 	})
 	assertion.Nil(err)
 }
@@ -119,15 +227,17 @@ func TestMapToInferenceServiceInvalid(t *testing.T) {
 	assertion, m := setup(t)
 	_, err := m.MapToInferenceService(&proto.Context{
 		TypeId: of(invalidTypeId),
+		Type:   of("odh.OtherEntity"),
 	})
 	assertion.NotNil(err)
-	assertion.Equal(fmt.Sprintf("invalid TypeId, expected %d but received %d", inferenceServiceTypeId, invalidTypeId), err.Error())
+	assertion.Equal(fmt.Sprintf("invalid entity: expected %s but received odh.OtherEntity, please check the provided id", constants.InferenceServiceTypeName), err.Error())
 }
 
 func TestMapToServeModel(t *testing.T) {
 	assertion, m := setup(t)
 	_, err := m.MapToServeModel(&proto.Execution{
 		TypeId: of(serveModelTypeId),
+		Type:   of(constants.ServeModelTypeName),
 	})
 	assertion.Nil(err)
 }
@@ -136,9 +246,16 @@ func TestMapToServeModelInvalid(t *testing.T) {
 	assertion, m := setup(t)
 	_, err := m.MapToServeModel(&proto.Execution{
 		TypeId: of(invalidTypeId),
+		Type:   of("odh.OtherEntity"),
 	})
 	assertion.NotNil(err)
-	assertion.Equal(fmt.Sprintf("invalid TypeId, expected %d but received %d", serveModelTypeId, invalidTypeId), err.Error())
+	assertion.Equal(fmt.Sprintf("invalid entity: expected %s but received odh.OtherEntity, please check the provided id", constants.ServeModelTypeName), err.Error())
+}
+
+func TestMapTo(t *testing.T) {
+	_, err := mapTo[*proto.Execution, any](&proto.Execution{TypeId: of(registeredModelTypeId)}, typesMap, "notExisitingTypeName", func(e *proto.Execution) (*any, error) { return nil, nil })
+	assert.NotNil(t, err)
+	assert.Equal(t, "unknown type name provided: notExisitingTypeName", err.Error())
 }
 
 // of returns a pointer to the provided literal/const input


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/opendatahub-io/model-registry/issues/217

## Description
<!--- Describe your changes in detail -->

As per linked issue, I managed to keep track of the maaping between the internal MLMD typedId and the corresponding name (avoiding to perform additional request on MLMD just to retrieve the name).

Following the "How to reproduce" steps in the issue, the final error result is:
```bash
"message":"invalid entity: expected odh.ModelVersion but received odh.RegisteredModel, please check the provided id"
```

I think this could be much more helpful/useful from user perspective.

In addition to this specific err mgmt I added:
* Moved odh MLMD types in a separated `constants.go` file, easier to keep track of them.
* Improved the `mapper` coverage

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```bash
make test-cover
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
