### PR TITLE
py: types: add state property to contexts

### DIFF
--- a/clients/python/src/model_registry/types/__init__.py
+++ b/clients/python/src/model_registry/types/__init__.py
@@ -4,7 +4,7 @@ Types are based on [ML Metadata](https://github.com/google/ml-metadata), with Py
 """
 
 from .artifacts import ArtifactState, ModelArtifact
-from .contexts import ModelVersion, RegisteredModel
+from .contexts import ContextState, ModelVersion, RegisteredModel
 from .options import ListOptions, OrderByField
 
 __all__ = [
@@ -14,6 +14,7 @@ __all__ = [
     # Contexts
     "ModelVersion",
     "RegisteredModel",
+    "ContextState",
     # Options
     "ListOptions",
     "OrderByField",

--- a/clients/python/src/model_registry/types/artifacts.py
+++ b/clients/python/src/model_registry/types/artifacts.py
@@ -58,7 +58,7 @@ class BaseArtifact(ProtoBase):
     def map(self, type_id: int) -> Artifact:
         mlmd_obj = super().map(type_id)
         mlmd_obj.uri = self.uri
-        mlmd_obj.state = ArtifactState[self.state.name].value
+        mlmd_obj.state = self.state.value
         return mlmd_obj
 
     @classmethod

--- a/clients/python/tests/conftest.py
+++ b/clients/python/tests/conftest.py
@@ -52,6 +52,7 @@ def store_wrapper(plain_wrapper: MLMDStore) -> MLMDStore:
             "author",
             "description",
             "model_name",
+            "state",
             "tags",
         ],
     )
@@ -63,6 +64,7 @@ def store_wrapper(plain_wrapper: MLMDStore) -> MLMDStore:
         RegisteredModel.get_proto_type_name(),
         [
             "description",
+            "state",
         ],
     )
 

--- a/clients/python/tests/test_core.py
+++ b/clients/python/tests/test_core.py
@@ -38,6 +38,7 @@ def model_version(store_wrapper: MLMDStore, model: Mapped) -> Mapped:
     ctx.type_id = store_wrapper.get_type_id(Context, ModelVersion.get_proto_type_name())
     ctx.properties["author"].string_value = "author"
     ctx.properties["model_name"].string_value = model.py.name
+    ctx.properties["state"].string_value = "LIVE"
 
     return Mapped(ctx, ModelVersion(model.py.name, "version", "author"))
 
@@ -49,6 +50,7 @@ def registered_model(store_wrapper: MLMDStore, model: Mapped) -> Mapped:
     ctx.type_id = store_wrapper.get_type_id(
         Context, RegisteredModel.get_proto_type_name()
     )
+    ctx.properties["state"].string_value = "LIVE"
 
     return Mapped(ctx, RegisteredModel(model.py.name))
 


### PR DESCRIPTION
Closes: #186

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add property `State` for RegisteredModel and ModelVersion context types on py client.

## How Has This Been Tested?
As a required property, fixtures have been updated to ensure `state` is always present.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
