### PR TITLE
GHA: fix python release action

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -48,7 +48,8 @@ jobs:
           poetry build --ansi
 
       - name: Publish package on PyPI
-        if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          verbose: true
+          print-hash: true
           packages-dir: clients/python/dist/

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -39,8 +39,11 @@ jobs:
         working-directory: clients/python
         run: |
           set -o pipefail
-          [[ $(poetry version | cut -d' ' -f1) == $(grep -o '[0-9\.]*' <<< "$GITHUB_REF") ]] ||\
-            echo "::error title='$GITHUB_REF tag does not match project version'::"
+          LATEST_TAG=$(git describe --tags --match="py-v*")
+          if [[ "$LATEST_TAG" =~ $(poetry version | cut -d' ' -f1) ]]; then
+            echo "::error title='$LATEST_TAG tag does not match project version'::"
+            exit 1
+          fi
 
       - name: Build package
         working-directory: clients/python

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -36,6 +36,7 @@ jobs:
           poetry --version
 
       - name: Check version
+        working-directory: clients/python
         run: |
           set -o pipefail
           [[ $(poetry version | cut -d' ' -f1) == $(grep -o '[0-9\.]*' <<< "$GITHUB_REF") ]] ||\


### PR DESCRIPTION
Fixes for Python release GHA.

## Description
One of the scripting steps on the workflow was supposed to be run from inside the `clients/python` folder (https://github.com/opendatahub-io/model-registry/actions/runs/7187592276/job/19575478612#step:7:16).

The publish action has also not been triggered due to [an incorrect check](https://github.com/opendatahub-io/model-registry/pull/239/files#diff-08d5d79624884efe962c68a256bee91079ad74acb3b22d61850797f5bf8aae04L50).

As manually dispatching the working can't rely on `$GITHUB_REF`, the version check has also been fixed to account for that. 

Some debug printing has also been added as noted on [the PyPI publish action docs](https://github.com/marketplace/actions/pypi-publish#for-debugging).

## How Has This Been Tested?
I'm not sure how to test that.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
