### PR TITLE
robot: fix Python client import

### DIFF
--- a/test/robot/MLMetadata.py
+++ b/test/robot/MLMetadata.py
@@ -1,19 +1,18 @@
-from ml_metadata.metadata_store import metadata_store
-from ml_metadata.metadata_store.metadata_store import ListOptions
-from ml_metadata.proto import metadata_store_pb2
 from ml_metadata import proto
-from typing import List, Optional
+from ml_metadata.metadata_store import metadata_store
+from ml_metadata.proto import metadata_store_pb2
+
 
 class MLMetadata(metadata_store.MetadataStore):
-    def __init__(self, host: str = 'localhost', port: int = 9090):
+    def __init__(self, host: str = "localhost", port: int = 9090):
         client_connection_config = metadata_store_pb2.MetadataStoreClientConfig()
         client_connection_config.host = host
         client_connection_config.port = port
         print(client_connection_config)
         super().__init__(client_connection_config)
 
-    def get_context_by_single_id(self, context_id: int) -> List[proto.Context]:
+    def get_context_by_single_id(self, context_id: int) -> list[proto.Context]:
         return self.get_contexts_by_id([context_id])[0]
 
-    def get_artifact_by_single_id(self, artifact_id: int) -> List[proto.Artifact]:
+    def get_artifact_by_single_id(self, artifact_id: int) -> list[proto.Artifact]:
         return self.get_artifacts_by_id([artifact_id])[0]

--- a/test/robot/ModelRegistry.py
+++ b/test/robot/ModelRegistry.py
@@ -2,13 +2,14 @@ import model_registry as mr
 from model_registry.types import ModelArtifact, ModelVersion, RegisteredModel
 from robot.libraries.BuiltIn import BuiltIn
 
+
 def write_to_console(s):
     print(s)
     BuiltIn().log_to_console(s)
 
 
-class ModelRegistry(mr.client.ModelRegistry):
-    def __init__(self, host: str = 'localhost', port: int = 9090):
+class ModelRegistry(mr.core.ModelRegistryAPIClient):
+    def __init__(self, host: str = "localhost", port: int = 9090):
         super().__init__(host, port)
 
     def upsert_registered_model(self, registered_model) -> str:
@@ -16,7 +17,7 @@ class ModelRegistry(mr.client.ModelRegistry):
         for key, value in registered_model.items():
             setattr(p, key, value)
         return super().upsert_registered_model(p)
-    
+
     def upsert_model_version(self, model_version, registered_model_id: str) -> str:
         write_to_console(model_version)
         p = ModelVersion(ModelArtifact("", ""), "", "")
@@ -24,7 +25,7 @@ class ModelRegistry(mr.client.ModelRegistry):
             setattr(p, key, value)
         write_to_console(p)
         return super().upsert_model_version(p, registered_model_id)
-    
+
     def upsert_model_artifact(self, model_artifact, model_version_id: str) -> str:
         write_to_console(model_artifact)
         p = ModelArtifact(None, None)
@@ -34,8 +35,8 @@ class ModelRegistry(mr.client.ModelRegistry):
         return super().upsert_model_artifact(p, model_version_id)
 
 
-# Used only for quick smoke tests 
+# Used only for quick smoke tests
 if __name__ == "__main__":
     demo_instance = ModelRegistry()
-    demo_instance.upsert_registered_model({'name': 'testing123'})
-    demo_instance.upsert_model_version({'name': 'v1'}, None)
+    demo_instance.upsert_registered_model({"name": "testing123"})
+    demo_instance.upsert_model_version({"name": "v1"}, None)

--- a/test/robot/ModelRegistry.py
+++ b/test/robot/ModelRegistry.py
@@ -13,14 +13,14 @@ class ModelRegistry(mr.core.ModelRegistryAPIClient):
         super().__init__(host, port)
 
     def upsert_registered_model(self, registered_model) -> str:
-        p = RegisteredModel(None)
+        p = RegisteredModel("")
         for key, value in registered_model.items():
             setattr(p, key, value)
         return super().upsert_registered_model(p)
 
     def upsert_model_version(self, model_version, registered_model_id: str) -> str:
         write_to_console(model_version)
-        p = ModelVersion(ModelArtifact("", ""), "", "")
+        p = ModelVersion("", "", "")
         for key, value in model_version.items():
             setattr(p, key, value)
         write_to_console(p)
@@ -28,7 +28,7 @@ class ModelRegistry(mr.core.ModelRegistryAPIClient):
 
     def upsert_model_artifact(self, model_artifact, model_version_id: str) -> str:
         write_to_console(model_artifact)
-        p = ModelArtifact(None, None)
+        p = ModelArtifact("", "")
         for key, value in model_artifact.items():
             setattr(p, key, value)
         write_to_console(p)


### PR DESCRIPTION
This fixes Robot tests for the Python client.

## Description
This fixes the imported python client on Robot tests to match what's exposed after adding a higher-level API.

## How Has This Been Tested?
I haven't managed to run robot locally successfully yet, but it seems the import problem has been fixed.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
