### PR TITLE
Change state to desiredState for InferenceService

### DIFF
--- a/api/openapi/model-registry.yaml
+++ b/api/openapi/model-registry.yaml
@@ -1576,7 +1576,7 @@ components:
             runtime:
               description: Model runtime.
               type: string
-            state:
+            desiredState:
               $ref: '#/components/schemas/InferenceServiceState'
     InferenceServiceCreate:
       description: >-

--- a/internal/converter/generated/mlmd_openapi_converter.gen.go
+++ b/internal/converter/generated/mlmd_openapi_converter.gen.go
@@ -33,7 +33,7 @@ func (c *MLMDToOpenAPIConverterImpl) ConvertInferenceService(source *proto.Conte
 		openapiInferenceService.LastUpdateTimeSinceEpoch = converter.Int64ToString((*source).LastUpdateTimeSinceEpoch)
 		openapiInferenceService.ModelVersionId = converter.MapPropertyModelVersionId((*source).Properties)
 		openapiInferenceService.Runtime = converter.MapPropertyRuntime((*source).Properties)
-		openapiInferenceService.State = converter.MapInferenceServiceState(source)
+		openapiInferenceService.DesiredState = converter.MapInferenceServiceDesiredState((*source).Properties)
 		openapiInferenceService.RegisteredModelId = converter.MapPropertyRegisteredModelId((*source).Properties)
 		openapiInferenceService.ServingEnvironmentId = converter.MapPropertyServingEnvironmentId((*source).Properties)
 		pOpenapiInferenceService = &openapiInferenceService
@@ -98,7 +98,7 @@ func (c *MLMDToOpenAPIConverterImpl) ConvertModelVersion(source *proto.Context) 
 		}
 		openapiModelVersion.ExternalID = pString
 		openapiModelVersion.Name = converter.MapNameFromOwned((*source).Name)
-		openapiModelVersion.State = converter.MapModelVersionState(source)
+		openapiModelVersion.State = converter.MapModelVersionState((*source).Properties)
 		openapiModelVersion.Author = converter.MapPropertyAuthor((*source).Properties)
 		openapiModelVersion.Id = converter.Int64ToString((*source).Id)
 		openapiModelVersion.CreateTimeSinceEpoch = converter.Int64ToString((*source).CreateTimeSinceEpoch)
@@ -132,7 +132,7 @@ func (c *MLMDToOpenAPIConverterImpl) ConvertRegisteredModel(source *proto.Contex
 		openapiRegisteredModel.Id = converter.Int64ToString((*source).Id)
 		openapiRegisteredModel.CreateTimeSinceEpoch = converter.Int64ToString((*source).CreateTimeSinceEpoch)
 		openapiRegisteredModel.LastUpdateTimeSinceEpoch = converter.Int64ToString((*source).LastUpdateTimeSinceEpoch)
-		openapiRegisteredModel.State = converter.MapRegisteredModelState(source)
+		openapiRegisteredModel.State = converter.MapRegisteredModelState((*source).Properties)
 		pOpenapiRegisteredModel = &openapiRegisteredModel
 	}
 	return pOpenapiRegisteredModel, nil

--- a/internal/converter/generated/openapi_converter.gen.go
+++ b/internal/converter/generated/openapi_converter.gen.go
@@ -53,11 +53,11 @@ func (c *OpenAPIConverterImpl) ConvertInferenceServiceCreate(source *openapi.Inf
 		}
 		openapiInferenceService.Runtime = pString5
 		var pOpenapiInferenceServiceState *openapi.InferenceServiceState
-		if (*source).State != nil {
-			openapiInferenceServiceState := openapi.InferenceServiceState(*(*source).State)
+		if (*source).DesiredState != nil {
+			openapiInferenceServiceState := openapi.InferenceServiceState(*(*source).DesiredState)
 			pOpenapiInferenceServiceState = &openapiInferenceServiceState
 		}
-		openapiInferenceService.State = pOpenapiInferenceServiceState
+		openapiInferenceService.DesiredState = pOpenapiInferenceServiceState
 		openapiInferenceService.RegisteredModelId = (*source).RegisteredModelId
 		openapiInferenceService.ServingEnvironmentId = (*source).ServingEnvironmentId
 		pOpenapiInferenceService = &openapiInferenceService
@@ -102,11 +102,11 @@ func (c *OpenAPIConverterImpl) ConvertInferenceServiceUpdate(source *openapi.Inf
 		}
 		openapiInferenceService.Runtime = pString4
 		var pOpenapiInferenceServiceState *openapi.InferenceServiceState
-		if (*source).State != nil {
-			openapiInferenceServiceState := openapi.InferenceServiceState(*(*source).State)
+		if (*source).DesiredState != nil {
+			openapiInferenceServiceState := openapi.InferenceServiceState(*(*source).DesiredState)
 			pOpenapiInferenceServiceState = &openapiInferenceServiceState
 		}
-		openapiInferenceService.State = pOpenapiInferenceServiceState
+		openapiInferenceService.DesiredState = pOpenapiInferenceServiceState
 		pOpenapiInferenceService = &openapiInferenceService
 	}
 	return pOpenapiInferenceService, nil

--- a/internal/converter/mlmd_converter_util_test.go
+++ b/internal/converter/mlmd_converter_util_test.go
@@ -544,13 +544,13 @@ func TestMapMLMDModelArtifactState(t *testing.T) {
 func TestMapRegisteredModelState(t *testing.T) {
 	assertion := setup(t)
 
-	state := MapRegisteredModelState(&proto.Context{Properties: map[string]*proto.Value{
+	state := MapRegisteredModelState(map[string]*proto.Value{
 		"state": {Value: &proto.Value_StringValue{StringValue: string(openapi.REGISTEREDMODELSTATE_LIVE)}},
-	}})
+	})
 	assertion.NotNil(state)
 	assertion.Equal(openapi.REGISTEREDMODELSTATE_LIVE, *state)
 
-	state = MapRegisteredModelState(&proto.Context{Properties: map[string]*proto.Value{}})
+	state = MapRegisteredModelState(map[string]*proto.Value{})
 	assertion.Nil(state)
 
 	state = MapRegisteredModelState(nil)
@@ -560,13 +560,13 @@ func TestMapRegisteredModelState(t *testing.T) {
 func TestMapModelVersionState(t *testing.T) {
 	assertion := setup(t)
 
-	state := MapModelVersionState(&proto.Context{Properties: map[string]*proto.Value{
+	state := MapModelVersionState(map[string]*proto.Value{
 		"state": {Value: &proto.Value_StringValue{StringValue: string(openapi.MODELVERSIONSTATE_LIVE)}},
-	}})
+	})
 	assertion.NotNil(state)
 	assertion.Equal(openapi.MODELVERSIONSTATE_LIVE, *state)
 
-	state = MapModelVersionState(&proto.Context{Properties: map[string]*proto.Value{}})
+	state = MapModelVersionState(map[string]*proto.Value{})
 	assertion.Nil(state)
 
 	state = MapModelVersionState(nil)
@@ -576,16 +576,16 @@ func TestMapModelVersionState(t *testing.T) {
 func TestMapInferenceServiceState(t *testing.T) {
 	assertion := setup(t)
 
-	state := MapInferenceServiceState(&proto.Context{Properties: map[string]*proto.Value{
-		"state": {Value: &proto.Value_StringValue{StringValue: string(openapi.INFERENCESERVICESTATE_DEPLOYED)}},
-	}})
+	state := MapInferenceServiceDesiredState(map[string]*proto.Value{
+		"desired_state": {Value: &proto.Value_StringValue{StringValue: string(openapi.INFERENCESERVICESTATE_DEPLOYED)}},
+	})
 	assertion.NotNil(state)
 	assertion.Equal(openapi.INFERENCESERVICESTATE_DEPLOYED, *state)
 
-	state = MapInferenceServiceState(&proto.Context{Properties: map[string]*proto.Value{}})
+	state = MapInferenceServiceDesiredState(map[string]*proto.Value{})
 	assertion.Nil(state)
 
-	state = MapInferenceServiceState(nil)
+	state = MapInferenceServiceDesiredState(nil)
 	assertion.Nil(state)
 }
 
@@ -614,14 +614,16 @@ func TestMapInferenceServiceProperties(t *testing.T) {
 		Runtime:              of("my-runtime"),
 		RegisteredModelId:    "2",
 		ServingEnvironmentId: "3",
+		DesiredState:         openapi.INFERENCESERVICESTATE_DEPLOYED.Ptr(),
 	})
 	assertion.Nil(err)
-	assertion.Equal(5, len(props))
+	assertion.Equal(6, len(props))
 	assertion.Equal("my custom description", props["description"].GetStringValue())
 	assertion.Equal(int64(1), props["model_version_id"].GetIntValue())
 	assertion.Equal("my-runtime", props["runtime"].GetStringValue())
 	assertion.Equal(int64(2), props["registered_model_id"].GetIntValue())
 	assertion.Equal(int64(3), props["serving_environment_id"].GetIntValue())
+	assertion.Equal("DEPLOYED", props["desired_state"].GetStringValue())
 
 	// serving and model id must be provided and must be a valid numeric id
 	_, err = MapInferenceServiceProperties(&openapi.InferenceService{})

--- a/internal/converter/mlmd_openapi_converter.go
+++ b/internal/converter/mlmd_openapi_converter.go
@@ -15,12 +15,12 @@ import (
 // goverter:extend MapMLMDCustomProperties
 type MLMDToOpenAPIConverter interface {
 	// goverter:map Properties Description | MapDescription
-	// goverter:map . State | MapRegisteredModelState
+	// goverter:map Properties State | MapRegisteredModelState
 	ConvertRegisteredModel(source *proto.Context) (*openapi.RegisteredModel, error)
 
 	// goverter:map Name | MapNameFromOwned
 	// goverter:map Properties Description | MapDescription
-	// goverter:map . State | MapModelVersionState
+	// goverter:map Properties State | MapModelVersionState
 	// goverter:map Properties Author | MapPropertyAuthor
 	ConvertModelVersion(source *proto.Context) (*openapi.ModelVersion, error)
 
@@ -45,7 +45,7 @@ type MLMDToOpenAPIConverter interface {
 	// goverter:map Properties ModelVersionId | MapPropertyModelVersionId
 	// goverter:map Properties RegisteredModelId | MapPropertyRegisteredModelId
 	// goverter:map Properties ServingEnvironmentId | MapPropertyServingEnvironmentId
-	// goverter:map . State | MapInferenceServiceState
+	// goverter:map Properties DesiredState | MapInferenceServiceDesiredState
 	ConvertInferenceService(source *proto.Context) (*openapi.InferenceService, error)
 
 	// goverter:map Name | MapNameFromOwned

--- a/internal/converter/mlmd_openapi_converter_util.go
+++ b/internal/converter/mlmd_openapi_converter_util.go
@@ -89,12 +89,8 @@ func MapArtifactType(source *proto.Artifact) (string, error) {
 	return "", fmt.Errorf("invalid artifact type found: %v", source.Type)
 }
 
-func MapRegisteredModelState(source *proto.Context) *openapi.RegisteredModelState {
-	if source == nil || source.GetProperties() == nil {
-		return nil
-	}
-
-	state, ok := source.GetProperties()["state"]
+func MapRegisteredModelState(properties map[string]*proto.Value) *openapi.RegisteredModelState {
+	state, ok := properties["state"]
 	if !ok {
 		return nil
 	}
@@ -102,12 +98,8 @@ func MapRegisteredModelState(source *proto.Context) *openapi.RegisteredModelStat
 	return (*openapi.RegisteredModelState)(&str)
 }
 
-func MapModelVersionState(source *proto.Context) *openapi.ModelVersionState {
-	if source == nil || source.GetProperties() == nil {
-		return nil
-	}
-
-	state, ok := source.GetProperties()["state"]
+func MapModelVersionState(properties map[string]*proto.Value) *openapi.ModelVersionState {
+	state, ok := properties["state"]
 	if !ok {
 		return nil
 	}
@@ -115,12 +107,8 @@ func MapModelVersionState(source *proto.Context) *openapi.ModelVersionState {
 	return (*openapi.ModelVersionState)(&str)
 }
 
-func MapInferenceServiceState(source *proto.Context) *openapi.InferenceServiceState {
-	if source == nil || source.GetProperties() == nil {
-		return nil
-	}
-
-	state, ok := source.GetProperties()["state"]
+func MapInferenceServiceDesiredState(properties map[string]*proto.Value) *openapi.InferenceServiceState {
+	state, ok := properties["desired_state"]
 	if !ok {
 		return nil
 	}

--- a/internal/converter/openapi_converter.go
+++ b/internal/converter/openapi_converter.go
@@ -76,7 +76,7 @@ type OpenAPIConverter interface {
 	// Ignore all fields that ARE editable
 	// goverter:default InitInferenceServiceWithUpdate
 	// goverter:autoMap Existing
-	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Description ExternalID CustomProperties ModelVersionId Runtime State
+	// goverter:ignore Id CreateTimeSinceEpoch LastUpdateTimeSinceEpoch Description ExternalID CustomProperties ModelVersionId Runtime DesiredState
 	OverrideNotEditableForInferenceService(source OpenapiUpdateWrapper[openapi.InferenceService]) (openapi.InferenceService, error)
 
 	// Ignore all fields that ARE editable

--- a/internal/converter/openapi_mlmd_converter_util.go
+++ b/internal/converter/openapi_mlmd_converter_util.go
@@ -336,10 +336,10 @@ func MapInferenceServiceProperties(source *openapi.InferenceService) (map[string
 			}
 		}
 
-		if source.State != nil {
-			props["state"] = &proto.Value{
+		if source.DesiredState != nil {
+			props["desired_state"] = &proto.Value{
 				Value: &proto.Value_StringValue{
-					StringValue: string(*source.State),
+					StringValue: string(*source.DesiredState),
 				},
 			}
 		}

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -107,7 +107,7 @@ func NewModelRegistryService(cc grpc.ClientConnInterface) (api.ModelRegistryApi,
 				// same information tracked using ParentContext association
 				"serving_environment_id": proto.PropertyType_INT,
 				"runtime":                proto.PropertyType_STRING,
-				"state":                  proto.PropertyType_STRING,
+				"desired_state":          proto.PropertyType_STRING,
 			},
 		},
 	}

--- a/pkg/core/core_test.go
+++ b/pkg/core/core_test.go
@@ -2125,7 +2125,7 @@ func (suite *CoreTestSuite) TestCreateInferenceService() {
 	parentResourceId := suite.registerServingEnvironment(service, nil, nil)
 	registeredModelId := suite.registerModel(service, nil, nil)
 	runtime := "model-server"
-	state := openapi.INFERENCESERVICESTATE_DEPLOYED
+	desiredState := openapi.INFERENCESERVICESTATE_DEPLOYED
 
 	eut := &openapi.InferenceService{
 		Name:                 &entityName,
@@ -2134,7 +2134,7 @@ func (suite *CoreTestSuite) TestCreateInferenceService() {
 		ServingEnvironmentId: parentResourceId,
 		RegisteredModelId:    registeredModelId,
 		Runtime:              &runtime,
-		State:                &state,
+		DesiredState:         &desiredState,
 		CustomProperties: &map[string]openapi.MetadataValue{
 			"custom_string_prop": {
 				MetadataStringValue: &openapi.MetadataStringValue{
@@ -2165,7 +2165,7 @@ func (suite *CoreTestSuite) TestCreateInferenceService() {
 	suite.Equal(customString, byId.Contexts[0].CustomProperties["custom_string_prop"].GetStringValue(), "saved custom_string_prop custom property should match the provided one")
 	suite.Equal(entityDescription, byId.Contexts[0].Properties["description"].GetStringValue(), "saved description should match the provided one")
 	suite.Equal(runtime, byId.Contexts[0].Properties["runtime"].GetStringValue(), "saved runtime should match the provided one")
-	suite.Equal(string(state), byId.Contexts[0].Properties["state"].GetStringValue(), "saved state should match the provided one")
+	suite.Equal(string(desiredState), byId.Contexts[0].Properties["desired_state"].GetStringValue(), "saved state should match the provided one")
 	suite.Equalf(*inferenceServiceTypeName, *byId.Contexts[0].Type, "saved context should be of type of %s", *inferenceServiceTypeName)
 
 	getAllResp, err := suite.mlmdClient.GetContexts(context.Background(), &proto.GetContextsRequest{})
@@ -2359,7 +2359,7 @@ func (suite *CoreTestSuite) TestGetInferenceServiceById() {
 		Description:          &entityDescription,
 		ServingEnvironmentId: parentResourceId,
 		RegisteredModelId:    registeredModelId,
-		State:                &state,
+		DesiredState:         &state,
 		CustomProperties: &map[string]openapi.MetadataValue{
 			"custom_string_prop": {
 				MetadataStringValue: &openapi.MetadataStringValue{
@@ -2389,7 +2389,7 @@ func (suite *CoreTestSuite) TestGetInferenceServiceById() {
 	suite.Equal(*getById.Id, *converter.Int64ToString(ctx.Id), "returned id should match the mlmd context one")
 	suite.Equal(*eut.Name, *getById.Name, "saved name should match the provided one")
 	suite.Equal(*eut.ExternalID, *getById.ExternalID, "saved external id should match the provided one")
-	suite.Equal(*eut.State, *getById.State, "saved state should match the provided one")
+	suite.Equal(*eut.DesiredState, *getById.DesiredState, "saved state should match the provided one")
 	suite.Equal(*(*getById.CustomProperties)["custom_string_prop"].MetadataStringValue.StringValue, customString, "saved custom_string_prop custom property should match the provided one")
 }
 

--- a/pkg/openapi/model_inference_service.go
+++ b/pkg/openapi/model_inference_service.go
@@ -36,8 +36,8 @@ type InferenceService struct {
 	// ID of the `ModelVersion` to serve. If it's unspecified, then the latest `ModelVersion` by creation order will be served.
 	ModelVersionId *string `json:"modelVersionId,omitempty"`
 	// Model runtime.
-	Runtime *string                `json:"runtime,omitempty"`
-	State   *InferenceServiceState `json:"state,omitempty"`
+	Runtime      *string                `json:"runtime,omitempty"`
+	DesiredState *InferenceServiceState `json:"desiredState,omitempty"`
 	// ID of the `RegisteredModel` to serve.
 	RegisteredModelId string `json:"registeredModelId"`
 	// ID of the parent `ServingEnvironment` for this `InferenceService` entity.
@@ -50,8 +50,8 @@ type InferenceService struct {
 // will change when the set of required properties is changed
 func NewInferenceService(registeredModelId string, servingEnvironmentId string) *InferenceService {
 	this := InferenceService{}
-	var state InferenceServiceState = INFERENCESERVICESTATE_DEPLOYED
-	this.State = &state
+	var desiredState InferenceServiceState = INFERENCESERVICESTATE_DEPLOYED
+	this.DesiredState = &desiredState
 	this.RegisteredModelId = registeredModelId
 	this.ServingEnvironmentId = servingEnvironmentId
 	return &this
@@ -62,8 +62,8 @@ func NewInferenceService(registeredModelId string, servingEnvironmentId string) 
 // but it doesn't guarantee that properties required by API are set
 func NewInferenceServiceWithDefaults() *InferenceService {
 	this := InferenceService{}
-	var state InferenceServiceState = INFERENCESERVICESTATE_DEPLOYED
-	this.State = &state
+	var desiredState InferenceServiceState = INFERENCESERVICESTATE_DEPLOYED
+	this.DesiredState = &desiredState
 	return &this
 }
 
@@ -355,36 +355,36 @@ func (o *InferenceService) SetRuntime(v string) {
 	o.Runtime = &v
 }
 
-// GetState returns the State field value if set, zero value otherwise.
-func (o *InferenceService) GetState() InferenceServiceState {
-	if o == nil || IsNil(o.State) {
+// GetDesiredState returns the DesiredState field value if set, zero value otherwise.
+func (o *InferenceService) GetDesiredState() InferenceServiceState {
+	if o == nil || IsNil(o.DesiredState) {
 		var ret InferenceServiceState
 		return ret
 	}
-	return *o.State
+	return *o.DesiredState
 }
 
-// GetStateOk returns a tuple with the State field value if set, nil otherwise
+// GetDesiredStateOk returns a tuple with the DesiredState field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InferenceService) GetStateOk() (*InferenceServiceState, bool) {
-	if o == nil || IsNil(o.State) {
+func (o *InferenceService) GetDesiredStateOk() (*InferenceServiceState, bool) {
+	if o == nil || IsNil(o.DesiredState) {
 		return nil, false
 	}
-	return o.State, true
+	return o.DesiredState, true
 }
 
-// HasState returns a boolean if a field has been set.
-func (o *InferenceService) HasState() bool {
-	if o != nil && !IsNil(o.State) {
+// HasDesiredState returns a boolean if a field has been set.
+func (o *InferenceService) HasDesiredState() bool {
+	if o != nil && !IsNil(o.DesiredState) {
 		return true
 	}
 
 	return false
 }
 
-// SetState gets a reference to the given InferenceServiceState and assigns it to the State field.
-func (o *InferenceService) SetState(v InferenceServiceState) {
-	o.State = &v
+// SetDesiredState gets a reference to the given InferenceServiceState and assigns it to the DesiredState field.
+func (o *InferenceService) SetDesiredState(v InferenceServiceState) {
+	o.DesiredState = &v
 }
 
 // GetRegisteredModelId returns the RegisteredModelId field value
@@ -472,8 +472,8 @@ func (o InferenceService) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Runtime) {
 		toSerialize["runtime"] = o.Runtime
 	}
-	if !IsNil(o.State) {
-		toSerialize["state"] = o.State
+	if !IsNil(o.DesiredState) {
+		toSerialize["desiredState"] = o.DesiredState
 	}
 	toSerialize["registeredModelId"] = o.RegisteredModelId
 	toSerialize["servingEnvironmentId"] = o.ServingEnvironmentId

--- a/pkg/openapi/model_inference_service_create.go
+++ b/pkg/openapi/model_inference_service_create.go
@@ -30,8 +30,8 @@ type InferenceServiceCreate struct {
 	// ID of the `ModelVersion` to serve. If it's unspecified, then the latest `ModelVersion` by creation order will be served.
 	ModelVersionId *string `json:"modelVersionId,omitempty"`
 	// Model runtime.
-	Runtime *string                `json:"runtime,omitempty"`
-	State   *InferenceServiceState `json:"state,omitempty"`
+	Runtime      *string                `json:"runtime,omitempty"`
+	DesiredState *InferenceServiceState `json:"desiredState,omitempty"`
 	// ID of the `RegisteredModel` to serve.
 	RegisteredModelId string `json:"registeredModelId"`
 	// ID of the parent `ServingEnvironment` for this `InferenceService` entity.
@@ -44,8 +44,8 @@ type InferenceServiceCreate struct {
 // will change when the set of required properties is changed
 func NewInferenceServiceCreate(registeredModelId string, servingEnvironmentId string) *InferenceServiceCreate {
 	this := InferenceServiceCreate{}
-	var state InferenceServiceState = INFERENCESERVICESTATE_DEPLOYED
-	this.State = &state
+	var desiredState InferenceServiceState = INFERENCESERVICESTATE_DEPLOYED
+	this.DesiredState = &desiredState
 	this.RegisteredModelId = registeredModelId
 	this.ServingEnvironmentId = servingEnvironmentId
 	return &this
@@ -56,8 +56,8 @@ func NewInferenceServiceCreate(registeredModelId string, servingEnvironmentId st
 // but it doesn't guarantee that properties required by API are set
 func NewInferenceServiceCreateWithDefaults() *InferenceServiceCreate {
 	this := InferenceServiceCreate{}
-	var state InferenceServiceState = INFERENCESERVICESTATE_DEPLOYED
-	this.State = &state
+	var desiredState InferenceServiceState = INFERENCESERVICESTATE_DEPLOYED
+	this.DesiredState = &desiredState
 	return &this
 }
 
@@ -253,36 +253,36 @@ func (o *InferenceServiceCreate) SetRuntime(v string) {
 	o.Runtime = &v
 }
 
-// GetState returns the State field value if set, zero value otherwise.
-func (o *InferenceServiceCreate) GetState() InferenceServiceState {
-	if o == nil || IsNil(o.State) {
+// GetDesiredState returns the DesiredState field value if set, zero value otherwise.
+func (o *InferenceServiceCreate) GetDesiredState() InferenceServiceState {
+	if o == nil || IsNil(o.DesiredState) {
 		var ret InferenceServiceState
 		return ret
 	}
-	return *o.State
+	return *o.DesiredState
 }
 
-// GetStateOk returns a tuple with the State field value if set, nil otherwise
+// GetDesiredStateOk returns a tuple with the DesiredState field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InferenceServiceCreate) GetStateOk() (*InferenceServiceState, bool) {
-	if o == nil || IsNil(o.State) {
+func (o *InferenceServiceCreate) GetDesiredStateOk() (*InferenceServiceState, bool) {
+	if o == nil || IsNil(o.DesiredState) {
 		return nil, false
 	}
-	return o.State, true
+	return o.DesiredState, true
 }
 
-// HasState returns a boolean if a field has been set.
-func (o *InferenceServiceCreate) HasState() bool {
-	if o != nil && !IsNil(o.State) {
+// HasDesiredState returns a boolean if a field has been set.
+func (o *InferenceServiceCreate) HasDesiredState() bool {
+	if o != nil && !IsNil(o.DesiredState) {
 		return true
 	}
 
 	return false
 }
 
-// SetState gets a reference to the given InferenceServiceState and assigns it to the State field.
-func (o *InferenceServiceCreate) SetState(v InferenceServiceState) {
-	o.State = &v
+// SetDesiredState gets a reference to the given InferenceServiceState and assigns it to the DesiredState field.
+func (o *InferenceServiceCreate) SetDesiredState(v InferenceServiceState) {
+	o.DesiredState = &v
 }
 
 // GetRegisteredModelId returns the RegisteredModelId field value
@@ -361,8 +361,8 @@ func (o InferenceServiceCreate) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Runtime) {
 		toSerialize["runtime"] = o.Runtime
 	}
-	if !IsNil(o.State) {
-		toSerialize["state"] = o.State
+	if !IsNil(o.DesiredState) {
+		toSerialize["desiredState"] = o.DesiredState
 	}
 	toSerialize["registeredModelId"] = o.RegisteredModelId
 	toSerialize["servingEnvironmentId"] = o.ServingEnvironmentId

--- a/pkg/openapi/model_inference_service_update.go
+++ b/pkg/openapi/model_inference_service_update.go
@@ -28,8 +28,8 @@ type InferenceServiceUpdate struct {
 	// ID of the `ModelVersion` to serve. If it's unspecified, then the latest `ModelVersion` by creation order will be served.
 	ModelVersionId *string `json:"modelVersionId,omitempty"`
 	// Model runtime.
-	Runtime *string                `json:"runtime,omitempty"`
-	State   *InferenceServiceState `json:"state,omitempty"`
+	Runtime      *string                `json:"runtime,omitempty"`
+	DesiredState *InferenceServiceState `json:"desiredState,omitempty"`
 }
 
 // NewInferenceServiceUpdate instantiates a new InferenceServiceUpdate object
@@ -38,8 +38,8 @@ type InferenceServiceUpdate struct {
 // will change when the set of required properties is changed
 func NewInferenceServiceUpdate() *InferenceServiceUpdate {
 	this := InferenceServiceUpdate{}
-	var state InferenceServiceState = INFERENCESERVICESTATE_DEPLOYED
-	this.State = &state
+	var desiredState InferenceServiceState = INFERENCESERVICESTATE_DEPLOYED
+	this.DesiredState = &desiredState
 	return &this
 }
 
@@ -48,8 +48,8 @@ func NewInferenceServiceUpdate() *InferenceServiceUpdate {
 // but it doesn't guarantee that properties required by API are set
 func NewInferenceServiceUpdateWithDefaults() *InferenceServiceUpdate {
 	this := InferenceServiceUpdate{}
-	var state InferenceServiceState = INFERENCESERVICESTATE_DEPLOYED
-	this.State = &state
+	var desiredState InferenceServiceState = INFERENCESERVICESTATE_DEPLOYED
+	this.DesiredState = &desiredState
 	return &this
 }
 
@@ -213,36 +213,36 @@ func (o *InferenceServiceUpdate) SetRuntime(v string) {
 	o.Runtime = &v
 }
 
-// GetState returns the State field value if set, zero value otherwise.
-func (o *InferenceServiceUpdate) GetState() InferenceServiceState {
-	if o == nil || IsNil(o.State) {
+// GetDesiredState returns the DesiredState field value if set, zero value otherwise.
+func (o *InferenceServiceUpdate) GetDesiredState() InferenceServiceState {
+	if o == nil || IsNil(o.DesiredState) {
 		var ret InferenceServiceState
 		return ret
 	}
-	return *o.State
+	return *o.DesiredState
 }
 
-// GetStateOk returns a tuple with the State field value if set, nil otherwise
+// GetDesiredStateOk returns a tuple with the DesiredState field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *InferenceServiceUpdate) GetStateOk() (*InferenceServiceState, bool) {
-	if o == nil || IsNil(o.State) {
+func (o *InferenceServiceUpdate) GetDesiredStateOk() (*InferenceServiceState, bool) {
+	if o == nil || IsNil(o.DesiredState) {
 		return nil, false
 	}
-	return o.State, true
+	return o.DesiredState, true
 }
 
-// HasState returns a boolean if a field has been set.
-func (o *InferenceServiceUpdate) HasState() bool {
-	if o != nil && !IsNil(o.State) {
+// HasDesiredState returns a boolean if a field has been set.
+func (o *InferenceServiceUpdate) HasDesiredState() bool {
+	if o != nil && !IsNil(o.DesiredState) {
 		return true
 	}
 
 	return false
 }
 
-// SetState gets a reference to the given InferenceServiceState and assigns it to the State field.
-func (o *InferenceServiceUpdate) SetState(v InferenceServiceState) {
-	o.State = &v
+// SetDesiredState gets a reference to the given InferenceServiceState and assigns it to the DesiredState field.
+func (o *InferenceServiceUpdate) SetDesiredState(v InferenceServiceState) {
+	o.DesiredState = &v
 }
 
 func (o InferenceServiceUpdate) MarshalJSON() ([]byte, error) {
@@ -270,8 +270,8 @@ func (o InferenceServiceUpdate) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Runtime) {
 		toSerialize["runtime"] = o.Runtime
 	}
-	if !IsNil(o.State) {
-		toSerialize["state"] = o.State
+	if !IsNil(o.DesiredState) {
+		toSerialize["desiredState"] = o.DesiredState
 	}
 	return toSerialize, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/opendatahub-io/model-registry/issues/229

## Description
As the `state` property in `InferenceService` is an "intention", set by user, to do something we decided to change the property name from `state` to `desiredState`
- [x] Change in openapi specification
- [x] Change in core and mlmd type property

> Change in python client is not needed as Serving interaction are not implemented there yet

> NOTE: since there is NOT a release yet I renamed the property in mlmd, keep in mind that if you have some DBs running with the old schema you might have to delete it and recreate as MLMD does not accept to rename properties. Maybe this is something we could take into account later, i.e, trying to be resilient to schema changes (or just be everytime backward compatible)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Go tests
```bash
make test
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
