### PR TITLE
Fix rest params order

### DIFF
--- a/internal/server/openapi/api_model_registry_service_service.go
+++ b/internal/server/openapi/api_model_registry_service_service.go
@@ -185,7 +185,7 @@ func (s *ModelRegistryServiceAPIService) FindInferenceService(ctx context.Contex
 
 // FindModelArtifact - Get a ModelArtifact that matches search parameters.
 func (s *ModelRegistryServiceAPIService) FindModelArtifact(ctx context.Context, name string, externalID string, parentResourceID string) (ImplResponse, error) {
-	result, err := s.coreApi.GetModelArtifactByParams(&name, &externalID, &parentResourceID)
+	result, err := s.coreApi.GetModelArtifactByParams(&name, &parentResourceID, &externalID)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}
@@ -197,7 +197,7 @@ func (s *ModelRegistryServiceAPIService) FindModelArtifact(ctx context.Context, 
 
 // FindModelVersion - Get a ModelVersion that matches search parameters.
 func (s *ModelRegistryServiceAPIService) FindModelVersion(ctx context.Context, name string, externalID string, registeredModelID string) (ImplResponse, error) {
-	result, err := s.coreApi.GetModelVersionByParams(&name, &externalID, &registeredModelID)
+	result, err := s.coreApi.GetModelVersionByParams(&name, &registeredModelID, &externalID)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
REST layer is calling `*ByParams` core api providing `ExternalID` and `ParentResourceID` in wrong order.

## How Has This Been Tested?

1. Create registered model and model version
2. Run `curl -X 'GET' \
  'https://localhost:8080/api/model_registry/v1alpha1/model_version?name={VERSION_NA<E}&parentResouceID={REG_MODEL_ID}`
3. You'll get the correct result by providing the reg model id

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
