### PR TITLE
Py: Add support for importing models from Hugging Face Hub

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -12,15 +12,23 @@ from model_registry import ModelRegistry
 
 registry = ModelRegistry(server_address="server-address", port=9090, author="author")
 
-model = registry.register_model("my-model",
-                                "s3://path/to/model",
-                                model_format_name="onnx",
-                                model_format_version="1",
-                                storage_key="aws-connection-path",
-                                storage_path="to/model",
-                                version="v2.0",
-                                description="lorem ipsum",
-                                )
+model = registry.register_model(
+    "my-model",  # model name
+    "s3://path/to/model",  # model URI
+    version="2.0.0",
+    description="lorem ipsum",
+    model_format_name="onnx",
+    model_format_version="1",
+    storage_key="aws-connection-path",
+    storage_path="path/to/model",
+    metadata={
+        # can be one of the following types
+        "int_key": 1,
+        "bool_key": False,
+        "float_key": 3.14,
+        "str_key": "str_value",
+    }
+)
 
 model = registry.get_registered_model("my-model")
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -37,6 +37,41 @@ version = registry.get_model_version("my-model", "v2.0")
 experiment = registry.get_model_artifact("my-model", "v2.0")
 ```
 
+### Importing from Hugging Face Hub
+
+To import models from Hugging Face Hub, start by installing the `huggingface-hub` package, either directly or as an
+extra (available as `model-registry[hf]`).
+Models can be imported with
+
+```py
+hf_model = registry.register_hf_model(
+    "hf-namespace/hf-model",  # HF repo
+    "relative/path/to/model/file.onnx",
+    version="1.2.3",
+    model_name="my-model",
+    description="lorem ipsum",
+    model_format_name="onnx",
+    model_format_version="1",
+)
+```
+
+There are caveats to be noted when using this method:
+
+- It's only possible to import a single model file per Hugging Face Hub repo right now.
+- If the model you want to import is in a global namespace, you should provide an author, e.g.
+
+    ```py
+    hf_model = registry.register_hf_model(
+        "gpt2",  # this model implicitly has no author
+        "onnx/decoder_model.onnx",
+        author="OpenAI",  # Defaults to unknown in the absence of an author
+        version="1.0.0",
+        description="gpt-2 model",
+        model_format_name="onnx",
+        model_format_version="1",
+    )
+    ```
+
 ## Development
 
 Common tasks, such as building documentation and running tests, can be executed using [`nox`](https://github.com/wntrblm/nox) sessions.

--- a/clients/python/noxfile.py
+++ b/clients/python/noxfile.py
@@ -49,7 +49,14 @@ def mypy(session: Session) -> None:
 def tests(session: Session) -> None:
     """Run the test suite."""
     session.install(".")
-    session.install("coverage[toml]", "pytest", "pytest-cov", "pygments", "testcontainers")
+    session.install(
+        "coverage[toml]",
+        "pytest",
+        "pytest-cov",
+        "pygments",
+        "testcontainers",
+        "huggingface-hub",
+    )
     try:
         session.run(
             "pytest",

--- a/clients/python/poetry.lock
+++ b/clients/python/poetry.lock
@@ -320,6 +320,57 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "filelock"
+version = "3.13.1"
+description = "A platform independent file lock."
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "filelock-3.13.1-py3-none-any.whl", hash = "sha256:57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c"},
+    {file = "filelock-3.13.1.tar.gz", hash = "sha256:521f5f56c50f8426f5e03ad3b281b490a87ef15bc6c526f168290f0c7148d44e"},
+]
+
+[package.extras]
+docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.24)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
+typing = ["typing-extensions (>=4.8)"]
+
+[[package]]
+name = "fsspec"
+version = "2023.12.2"
+description = "File-system specification"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "fsspec-2023.12.2-py3-none-any.whl", hash = "sha256:d800d87f72189a745fa3d6b033b9dc4a34ad069f60ca60b943a63599f5501960"},
+    {file = "fsspec-2023.12.2.tar.gz", hash = "sha256:8548d39e8810b59c38014934f6b31e57f40c1b20f911f4cc2b85389c7e9bf0cb"},
+]
+
+[package.extras]
+abfs = ["adlfs"]
+adl = ["adlfs"]
+arrow = ["pyarrow (>=1)"]
+dask = ["dask", "distributed"]
+devel = ["pytest", "pytest-cov"]
+dropbox = ["dropbox", "dropboxdrivefs", "requests"]
+full = ["adlfs", "aiohttp (!=4.0.0a0,!=4.0.0a1)", "dask", "distributed", "dropbox", "dropboxdrivefs", "fusepy", "gcsfs", "libarchive-c", "ocifs", "panel", "paramiko", "pyarrow (>=1)", "pygit2", "requests", "s3fs", "smbprotocol", "tqdm"]
+fuse = ["fusepy"]
+gcs = ["gcsfs"]
+git = ["pygit2"]
+github = ["requests"]
+gs = ["gcsfs"]
+gui = ["panel"]
+hdfs = ["pyarrow (>=1)"]
+http = ["aiohttp (!=4.0.0a0,!=4.0.0a1)", "requests"]
+libarchive = ["libarchive-c"]
+oci = ["ocifs"]
+s3 = ["s3fs"]
+sftp = ["paramiko"]
+smb = ["smbprotocol"]
+ssh = ["paramiko"]
+tqdm = ["tqdm"]
+
+[[package]]
 name = "furo"
 version = "2023.9.10"
 description = "A clean customisable Sphinx documentation theme."
@@ -401,6 +452,38 @@ files = [
 
 [package.extras]
 protobuf = ["grpcio-tools (>=1.59.3)"]
+
+[[package]]
+name = "huggingface-hub"
+version = "0.20.1"
+description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
+optional = true
+python-versions = ">=3.8.0"
+files = [
+    {file = "huggingface_hub-0.20.1-py3-none-any.whl", hash = "sha256:ecfdea395a8bc68cd160106c5bd857f7e010768d95f9e1862a779010cc304831"},
+    {file = "huggingface_hub-0.20.1.tar.gz", hash = "sha256:8c88c4c3c8853e22f2dfb4d84c3d493f4e1af52fb3856a90e1eeddcf191ddbb1"},
+]
+
+[package.dependencies]
+filelock = "*"
+fsspec = ">=2023.5.0"
+packaging = ">=20.9"
+pyyaml = ">=5.1"
+requests = "*"
+tqdm = ">=4.42.1"
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+all = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "gradio", "jedi", "mypy (==1.5.1)", "numpy", "pydantic (>1.1,<2.0)", "pydantic (>1.1,<3.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-rerunfailures", "pytest-vcr", "pytest-xdist", "ruff (>=0.1.3)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
+cli = ["InquirerPy (==0.3.4)"]
+dev = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "gradio", "jedi", "mypy (==1.5.1)", "numpy", "pydantic (>1.1,<2.0)", "pydantic (>1.1,<3.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-rerunfailures", "pytest-vcr", "pytest-xdist", "ruff (>=0.1.3)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
+fastai = ["fastai (>=2.4)", "fastcore (>=1.3.27)", "toml"]
+inference = ["aiohttp", "pydantic (>1.1,<2.0)", "pydantic (>1.1,<3.0)"]
+quality = ["mypy (==1.5.1)", "ruff (>=0.1.3)"]
+tensorflow = ["graphviz", "pydot", "tensorflow"]
+testing = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "aiohttp", "gradio", "jedi", "numpy", "pydantic (>1.1,<2.0)", "pydantic (>1.1,<3.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-rerunfailures", "pytest-vcr", "pytest-xdist", "soundfile", "urllib3 (<2.0)"]
+torch = ["torch"]
+typing = ["types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)"]
 
 [[package]]
 name = "idna"
@@ -1253,6 +1336,26 @@ files = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.66.1"
+description = "Fast, Extensible Progress Meter"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "tqdm-4.66.1-py3-none-any.whl", hash = "sha256:d302b3c5b53d47bce91fea46679d9c3c6508cf6332229aa1e7d8653723793386"},
+    {file = "tqdm-4.66.1.tar.gz", hash = "sha256:d88e651f9db8d8551a62556d3cff9e3034274ca5d66e93197cf2490e2dcb69c7"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["pytest (>=6)", "pytest-cov", "pytest-timeout", "pytest-xdist"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
 name = "typing-extensions"
 version = "4.8.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -1403,7 +1506,10 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
+[extras]
+hf = ["huggingface-hub"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.9, < 3.11"
-content-hash = "0bec6ced2c16af94b1fc60510507065880d70bf1f3e786da393233ee345ed15c"
+content-hash = "9a15e6a019ed38f48c6f58fa910b57d01492a59dd415423416ebf43084067d95"

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -16,6 +16,11 @@ ml-metadata = "^1.14.0"
 # ml-metadata = { url = "https://github.com/tarilabs/ml-metadata-remote/releases/download/1.14.0/ml_metadata-1.14.0-py3-none-any.whl" }
 typing-extensions = "^4.8"
 
+huggingface-hub = { version = "^0.20.1", optional = true }
+
+[tool.poetry.extras]
+hf = ["huggingface-hub"]
+
 [tool.poetry.group.dev.dependencies]
 sphinx = "^7.2.6"
 furo = "^2023.9.10"

--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -21,12 +21,12 @@ class ModelRegistry:
         """Constructor.
 
         Args:
-            server_address (str): Server address.
-            port (int): Server port.
-            author (str): Name of the author.
-            client_key (str, optional): The PEM-encoded private key as a byte string.
-            server_cert (str, optional): The PEM-encoded certificate as a byte string.
-            custom_ca (str, optional): The PEM-encoded root certificates as a byte string.
+            server_address: Server address.
+            port: Server port.
+            author: Name of the author.
+            client_key: The PEM-encoded private key as a byte string.
+            server_cert: The PEM-encoded certificate as a byte string.
+            custom_ca: The PEM-encoded root certificates as a byte string.
         """
         # TODO: get args from env
         self._author = author
@@ -77,24 +77,23 @@ class ModelRegistry:
     ) -> RegisteredModel:
         """Register a model.
 
-        Version has to be unique for the model.
         Either `storage_key` and `storage_path`, or `service_account_name` must be provided.
 
         Args:
-            name (str): Name of the model.
-            uri (str): URI of the model.
+            name: Name of the model.
+            uri: URI of the model.
 
         Keyword Args:
-            model_format_name (str): Name of the model format.
-            model_format_version (str): Version of the model format.
-            version (str): Version of the model.
-            description (str, optional): Description of the model.
-            storage_key (str, optional): Storage key.
-            storage_path (str, optional): Storage path.
-            service_account_name (str, optional): Service account name.
+            model_format_name: Name of the model format.
+            model_format_version: Version of the model format.
+            version: Version of the model. Has to be unique.
+            description: Description of the model.
+            storage_key: Storage key.
+            storage_path: Storage path.
+            service_account_name: Service account name.
 
         Returns:
-            RegisteredModel: Registered model.
+            Registered model.
         """
         rm = self._register_model(name)
         mv = self._register_new_version(rm, version, description=description)
@@ -110,39 +109,49 @@ class ModelRegistry:
 
         return rm
 
-    def get_registered_model(self, name: str) -> RegisteredModel:
+    def get_registered_model(self, name: str) -> RegisteredModel | None:
         """Get a registered model.
 
         Args:
-            name (str): Name of the model.
+            name: Name of the model.
 
         Returns:
-            RegisteredModel: Registered model.
+            Registered model.
         """
         return self._api.get_registered_model_by_params(name)
 
-    def get_model_version(self, name: str, version: str) -> ModelVersion:
+    def get_model_version(self, name: str, version: str) -> ModelVersion | None:
         """Get a model version.
 
         Args:
-            name (str): Name of the model.
-            version (str): Version of the model.
+            name: Name of the model.
+            version: Version of the model.
 
         Returns:
-            ModelVersion: Model version.
+            Model version.
+
+        Raises:
+            StoreException: If the model does not exist.
         """
-        rm = self._api.get_registered_model_by_params(name)
+        if not (rm := self._api.get_registered_model_by_params(name)):
+            msg = f"Model {name} does not exist"
+            raise StoreException(msg)
         return self._api.get_model_version_by_params(rm.id, version)
 
-    def get_model_artifact(self, name: str, version: str) -> ModelArtifact:
+    def get_model_artifact(self, name: str, version: str) -> ModelArtifact | None:
         """Get a model artifact.
 
         Args:
-            name (str): Name of the model.
-            version (str): Version of the model.
+            name: Name of the model.
+            version: Version of the model.
 
         Returns:
-            ModelArtifact: Model artifact.
+            Model artifact.
+
+        Raises:
+            StoreException: If either the model or the version don't exist.
         """
-        mv = self.get_model_version(name, version)
+        if not (mv := self.get_model_version(name, version)):
+            msg = f"Version {version} does not exist"
+            raise StoreException(msg)
         return self._api.get_model_artifact_by_params(mv.id)

--- a/clients/python/src/model_registry/core.py
+++ b/clients/python/src/model_registry/core.py
@@ -160,11 +160,10 @@ class ModelRegistryAPIClient:
         Returns:
             ID of the model version.
         """
-        rm_id = int(registered_model_id)
         # this is not ideal but we need this info for the prefix
-        model_version._registered_model_id = rm_id
+        model_version._registered_model_id = registered_model_id
         id = self._store.put_context(self._map(model_version))
-        self._store.put_context_parent(rm_id, id)
+        self._store.put_context_parent(int(registered_model_id), id)
         new_py_mv = ModelVersion.unmap(
             self._store.get_context(ModelVersion.get_proto_type_name(), id)
         )

--- a/clients/python/src/model_registry/store/wrapper.py
+++ b/clients/python/src/model_registry/store/wrapper.py
@@ -317,8 +317,8 @@ class MLMDStore:
         artifacts = self._filter_type(art_type_name, artifacts)
         if artifacts:
             return artifacts[0]
-        msg = "No artifacts found"
-        raise StoreException(msg)
+
+        return None
 
     def get_artifacts(
         self, art_type_name: str, options: ListOptions

--- a/clients/python/src/model_registry/types/base.py
+++ b/clients/python/src/model_registry/types/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, get_args
 
 from attrs import define, field
 from typing_extensions import override
@@ -160,19 +160,12 @@ class ProtoBase(Mappable, ABC):
             Python properties.
         """
         py_props: dict[str, ScalarType] = {}
-        for key, value in mlmd_props.items():
-            # TODO: use pattern matching here (3.10)
-            if value.HasField("bool_value"):
-                py_props[key] = value.bool_value
-            elif value.HasField("int_value"):
-                py_props[key] = value.int_value
-            elif value.HasField("double_value"):
-                py_props[key] = value.double_value
-            elif value.HasField("string_value"):
-                py_props[key] = value.string_value
-            else:
-                msg = f"Unsupported type: {type(value)}"
+        for key, prop in mlmd_props.items():
+            _, value = prop.ListFields()[0]
+            if not isinstance(value, get_args(ScalarType)):
+                msg = f"Unsupported type {type(value)} on key {key}"
                 raise Exception(msg)
+            py_props[key] = value
 
         return py_props
 

--- a/clients/python/src/model_registry/types/contexts.py
+++ b/clients/python/src/model_registry/types/contexts.py
@@ -81,8 +81,8 @@ class ModelVersion(BaseContext, Prefixable):
     model_name: str
     version: str
     author: str
+    metadata: dict[str, ScalarType] = field(factory=dict)
     artifacts: list[BaseArtifact] = field(init=False, factory=list)
-    metadata: dict[str, ScalarType] = field(init=False, factory=dict)
 
     _registered_model_id: str | None = field(init=False, default=None)
 

--- a/clients/python/src/model_registry/types/contexts.py
+++ b/clients/python/src/model_registry/types/contexts.py
@@ -86,14 +86,14 @@ class ModelVersion(BaseContext, Prefixable):
     tags: list[str] = field(init=False, factory=list)
     metadata: dict[str, ScalarType] = field(init=False, factory=dict)
 
-    _registered_model_id: int | None = field(init=False, default=None)
+    _registered_model_id: str | None = field(init=False, default=None)
 
     def __attrs_post_init__(self) -> None:
         self.name = self.version
 
     @property
     @override
-    def mlmd_name_prefix(self):
+    def mlmd_name_prefix(self) -> str:
         assert (
             self._registered_model_id is not None
         ), "There's no registered model associated with this version"

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -66,3 +66,37 @@ def test_get(mr_client: ModelRegistry):
     assert mv.id == _mv.id
     assert (_ma := mr_client.get_model_artifact(name, version))
     assert ma.id == _ma.id
+
+
+def test_hf_import(mr_client: ModelRegistry):
+    pytest.importorskip("huggingface_hub")
+    name = "gpt2"
+    version = "1.2.3"
+
+    assert mr_client.register_hf_model(
+        name,
+        "onnx/decoder_model.onnx",
+        author="test author",
+        version=version,
+        model_format_name="test format",
+        model_format_version="test version",
+    )
+    assert mr_client.get_model_version(name, version)
+    assert mr_client.get_model_artifact(name, version)
+
+
+def test_hf_import_missing_author(mr_client: ModelRegistry):
+    pytest.importorskip("huggingface_hub")
+    name = "gpt2"
+    version = "1.2.3"
+
+    with pytest.warns(match=r".*author is unknown.*"):
+        assert mr_client.register_hf_model(
+            name,
+            "onnx/decoder_model.onnx",
+            version=version,
+            model_format_name="test format",
+            model_format_version="test version",
+        )
+    assert (mv := mr_client.get_model_version(name, version))
+    assert mv.author == "unknown"

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -55,11 +55,14 @@ def test_get(mr_client: ModelRegistry):
         version=version,
     )
 
-    assert rm.id == mr_client.get_registered_model(name).id
+    assert (_rm := mr_client.get_registered_model(name))
+    assert rm.id == _rm.id
 
     mr_api = mr_client._api
-    mv = mr_api.get_model_version_by_params(rm.id, version)
-    ma = mr_api.get_model_artifact_by_params(mv.id)
+    assert (mv := mr_api.get_model_version_by_params(rm.id, version))
+    assert (ma := mr_api.get_model_artifact_by_params(mv.id))
 
-    assert mv.id == mr_client.get_model_version(name, version).id
-    assert ma.id == mr_client.get_model_artifact(name, version).id
+    assert (_mv := mr_client.get_model_version(name, version))
+    assert mv.id == _mv.id
+    assert (_ma := mr_client.get_model_artifact(name, version))
+    assert ma.id == _ma.id

--- a/clients/python/tests/test_core.py
+++ b/clients/python/tests/test_core.py
@@ -75,7 +75,7 @@ def test_get_registered_model_by_id(
 ):
     rm_id = mr_api._store._mlmd_store.put_contexts([registered_model.proto])[0]
 
-    mlmd_rm = mr_api.get_registered_model_by_id(str(rm_id))
+    assert (mlmd_rm := mr_api.get_registered_model_by_id(str(rm_id)))
     assert mlmd_rm.id == str(rm_id)
     assert mlmd_rm.name == registered_model.py.name
     assert mlmd_rm.name == registered_model.proto.name
@@ -87,7 +87,9 @@ def test_get_registered_model_by_name(
 ):
     rm_id = mr_api._store._mlmd_store.put_contexts([registered_model.proto])[0]
 
-    mlmd_rm = mr_api.get_registered_model_by_params(name=registered_model.py.name)
+    assert (
+        mlmd_rm := mr_api.get_registered_model_by_params(name=registered_model.py.name)
+    )
     assert mlmd_rm.id == str(rm_id)
     assert mlmd_rm.name == registered_model.py.name
     assert mlmd_rm.name == registered_model.proto.name
@@ -101,8 +103,10 @@ def test_get_registered_model_by_external_id(
     registered_model.proto.external_id = "external_id"
     rm_id = mr_api._store._mlmd_store.put_contexts([registered_model.proto])[0]
 
-    mlmd_rm = mr_api.get_registered_model_by_params(
-        external_id=registered_model.py.external_id
+    assert (
+        mlmd_rm := mr_api.get_registered_model_by_params(
+            external_id=registered_model.py.external_id
+        )
     )
     assert mlmd_rm.id == str(rm_id)
     assert mlmd_rm.name == registered_model.py.name
@@ -144,7 +148,7 @@ def test_get_model_version_by_id(mr_api: ModelRegistryAPIClient, model_version: 
     ctx_id = mr_api._store._mlmd_store.put_contexts([model_version.proto])[0]
 
     id = str(ctx_id)
-    mlmd_mv = mr_api.get_model_version_by_id(id)
+    assert (mlmd_mv := mr_api.get_model_version_by_id(id))
     assert mlmd_mv.id == id
     assert mlmd_mv.name == model_version.py.name
     assert mlmd_mv.version != model_version.proto.name
@@ -156,8 +160,10 @@ def test_get_model_version_by_name(
     model_version.proto.name = f"1:{model_version.proto.name}"
     mv_id = mr_api._store._mlmd_store.put_contexts([model_version.proto])[0]
 
-    mlmd_mv = mr_api.get_model_version_by_params(
-        registered_model_id="1", version=model_version.py.name
+    assert (
+        mlmd_mv := mr_api.get_model_version_by_params(
+            registered_model_id="1", version=model_version.py.name
+        )
     )
     assert mlmd_mv.id == str(mv_id)
     assert mlmd_mv.name == model_version.py.name
@@ -172,8 +178,10 @@ def test_get_model_version_by_external_id(
     model_version.py.external_id = "external_id"
     mv_id = mr_api._store._mlmd_store.put_contexts([model_version.proto])[0]
 
-    mlmd_mv = mr_api.get_model_version_by_params(
-        external_id=model_version.py.external_id
+    assert (
+        mlmd_mv := mr_api.get_model_version_by_params(
+            external_id=model_version.py.external_id
+        )
     )
     assert mlmd_mv.id == str(mv_id)
     assert mlmd_mv.name == model_version.py.name
@@ -266,8 +274,7 @@ def test_get_model_artifact_by_id(mr_api: ModelRegistryAPIClient, model: Mapped)
     id = mr_api._store._mlmd_store.put_artifacts([model.proto])[0]
     id = str(id)
 
-    mlmd_ma = mr_api.get_model_artifact_by_id(id)
-
+    assert (mlmd_ma := mr_api.get_model_artifact_by_id(id))
     assert mlmd_ma.id == id
     assert mlmd_ma.name == model.py.name
     assert mlmd_ma.name != model.proto.name
@@ -285,8 +292,7 @@ def test_get_model_artifact_by_model_version_id(
         [Attribution(context_id=mv_id, artifact_id=ma_id)], []
     )
 
-    mlmd_ma = mr_api.get_model_artifact_by_params(model_version_id=str(mv_id))
-
+    assert (mlmd_ma := mr_api.get_model_artifact_by_params(model_version_id=str(mv_id)))
     assert mlmd_ma.id == str(ma_id)
     assert mlmd_ma.name == model.py.name
     assert mlmd_ma.name != model.proto.name
@@ -302,8 +308,9 @@ def test_get_model_artifact_by_external_id(
     id = mr_api._store._mlmd_store.put_artifacts([model.proto])[0]
     id = str(id)
 
-    mlmd_ma = mr_api.get_model_artifact_by_params(external_id=model.py.external_id)
-
+    assert (
+        mlmd_ma := mr_api.get_model_artifact_by_params(external_id=model.py.external_id)
+    )
     assert mlmd_ma.id == id
     assert mlmd_ma.name == model.py.name
     assert mlmd_ma.name != model.proto.name

--- a/clients/python/tests/types/test_context_mapping.py
+++ b/clients/python/tests/types/test_context_mapping.py
@@ -34,7 +34,7 @@ def full_model_version() -> Mapped:
         external_id="test_external_id",
         description="test description",
     )
-    py_version._registered_model_id = 1
+    py_version._registered_model_id = "1"
     py_version.tags = ["test_tag1", "test_tag2"]
     py_version.metadata = {
         "int_key": 1,
@@ -56,7 +56,7 @@ def minimal_model_version() -> Mapped:
     proto_version.properties["state"].string_value = "LIVE"
 
     py_version = ModelVersion("test_model", "1.0.0", "test_author")
-    py_version._registered_model_id = 1
+    py_version._registered_model_id = "1"
     return Mapped(proto_version, py_version)
 
 

--- a/clients/python/tests/types/test_context_mapping.py
+++ b/clients/python/tests/types/test_context_mapping.py
@@ -20,7 +20,6 @@ def full_model_version() -> Mapped:
     proto_version.properties["description"].string_value = "test description"
     proto_version.properties["model_name"].string_value = "test_model"
     proto_version.properties["author"].string_value = "test_author"
-    proto_version.properties["tags"].string_value = "test_tag1,test_tag2"
     proto_version.properties["state"].string_value = "ARCHIVED"
     proto_version.custom_properties["int_key"].int_value = 1
     proto_version.custom_properties["float_key"].double_value = 1.0
@@ -35,7 +34,6 @@ def full_model_version() -> Mapped:
         description="test description",
     )
     py_version._registered_model_id = "1"
-    py_version.tags = ["test_tag1", "test_tag2"]
     py_version.metadata = {
         "int_key": 1,
         "float_key": 1.0,
@@ -75,7 +73,6 @@ def test_partial_model_version_unmapping(minimal_model_version: Mapped):
     assert unmapped_version.model_name == py_version.model_name
     assert unmapped_version.author == py_version.author
     assert unmapped_version.state == py_version.state
-    assert unmapped_version.tags == py_version.tags
     assert unmapped_version.metadata == py_version.metadata
 
 
@@ -98,5 +95,4 @@ def test_full_model_version_unmapping(full_model_version: Mapped):
     assert unmapped_version.model_name == py_version.model_name
     assert unmapped_version.author == py_version.author
     assert unmapped_version.state == py_version.state
-    assert unmapped_version.tags == py_version.tags
     assert unmapped_version.metadata == py_version.metadata

--- a/clients/python/tests/types/test_context_mapping.py
+++ b/clients/python/tests/types/test_context_mapping.py
@@ -13,10 +13,11 @@ from .. import Mapped
 
 @pytest.fixture()
 def full_model_version() -> Mapped:
-    proto_version = Context()
-    proto_version.name = "1:1.0.0"
-    proto_version.type_id = 2
-    proto_version.external_id = "test_external_id"
+    proto_version = Context(
+        name="1:1.0.0",
+        type_id=2,
+        external_id="test_external_id",
+    )
     proto_version.properties["description"].string_value = "test description"
     proto_version.properties["model_name"].string_value = "test_model"
     proto_version.properties["author"].string_value = "test_author"
@@ -32,23 +33,21 @@ def full_model_version() -> Mapped:
         "test_author",
         external_id="test_external_id",
         description="test description",
+        metadata={
+            "int_key": 1,
+            "float_key": 1.0,
+            "bool_key": True,
+            "str_key": "test_str",
+        },
     )
     py_version._registered_model_id = "1"
-    py_version.metadata = {
-        "int_key": 1,
-        "float_key": 1.0,
-        "bool_key": True,
-        "str_key": "test_str",
-    }
     py_version.state = ContextState.ARCHIVED
     return Mapped(proto_version, py_version)
 
 
 @pytest.fixture()
 def minimal_model_version() -> Mapped:
-    proto_version = Context()
-    proto_version.name = "1:1.0.0"
-    proto_version.type_id = 2
+    proto_version = Context(name="1:1.0.0", type_id=2)
     proto_version.properties["model_name"].string_value = "test_model"
     proto_version.properties["author"].string_value = "test_author"
     proto_version.properties["state"].string_value = "LIVE"


### PR DESCRIPTION
Related: #133

## Description

Fixes docstrings and some type errors, also simplifies type checking in `ProtoBase.unmap` and `MLMDStore.get_type_id`.

As laid out in https://github.com/opendatahub-io/model-registry/issues/133#issuecomment-1861912870, the API provides
utility calls to fetch metadata from a given Hub repo automatically.

The following metadata is fetched:
- Model author.
- Model ID.
- The [model card](https://huggingface.co/docs/hub/model-cards).

Additional data regarding the origin of the model is also stored in the model version created by the import.

TODO:
- [x] Skip feature tests if `huggingface-hub` lib isn't installed.
- [x] Import hf model author
- [x] Get metadata from user-provided git ref

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
