### PR TITLE
Updated depreciated [return] commands to use the RETURN keyword on robot tests

### DIFF
--- a/test/robot/MRkeywords.resource
+++ b/test/robot/MRkeywords.resource
@@ -21,7 +21,7 @@ I create a RegisteredModel having
         ${result}    Upsert Registered Model    ${data}
         Log to console    ${result}
     END
-    [return]    ${result}
+    RETURN    ${result}
 
 
 I create a RegisteredModel
@@ -34,7 +34,7 @@ I create a RegisteredModel
         ${result}    Upsert Registered Model    ${payload}
         Log to console    ${result}
     END
-    [return]    ${result}
+    RETURN    ${result}
 
 
 I create a child ModelVersion having
@@ -49,7 +49,7 @@ I create a child ModelVersion having
         ${result}    Upsert Model Version    ${data}     ${registeredModelID}
         Log to console    ${result}
     END
-    [return]    ${result}
+    RETURN    ${result}
 
 
 I create a child ModelVersion
@@ -63,7 +63,7 @@ I create a child ModelVersion
         ${result}    Upsert Model Version    ${payload}     ${registeredModelID}
         Log to console    ${result}
     END
-    [return]    ${result}
+    RETURN    ${result}
 
 
 I create a child ModelArtifact having
@@ -79,7 +79,7 @@ I create a child ModelArtifact having
         ${result}    Upsert Model Artifact    ${data}    ${modelversionId}
         Log to console    ${result}
     END
-    [return]    ${result}
+    RETURN    ${result}
 
 
 I create a child ModelArtifact
@@ -92,7 +92,7 @@ I create a child ModelArtifact
         ${result}    Upsert Model Artifact    ${payload}    ${modelversionId}
         Log to console    ${result}
     END
-    [return]    ${result}
+    RETURN    ${result}
 
 
 I get RegisteredModelByID
@@ -105,7 +105,7 @@ I get RegisteredModelByID
         Log to console    ${MODE}
         Fail    Not Implemented
     END
-    [return]    ${result}
+    RETURN    ${result}
 
 
 I get ModelVersionByID
@@ -118,7 +118,7 @@ I get ModelVersionByID
         Log to console    ${MODE}
         Fail    Not Implemented
     END
-    [return]    ${result}
+    RETURN    ${result}
 
 
 I get ModelArtifactByID
@@ -131,4 +131,4 @@ I get ModelArtifactByID
         Log to console    ${MODE}
         Fail    Not Implemented
     END
-    [return]    ${result}
+    RETURN    ${result}


### PR DESCRIPTION
Updated depreciated commands to use RETURN  Keyword
Prior to update

> ==============================================================================
Robot                                                                         
==============================================================================
[ WARN ] Error in file '/workspaces/model-registry/test/robot/MRkeywords.resource' on line 24: The '[Return]' setting is deprecated. Use the 'RETURN' statement instead.
[ WARN ] Error in file '/workspaces/model-registry/test/robot/MRkeywords.resource' on line 37: The '[Return]' setting is deprecated. Use the 'RETURN' statement instead.
[ WARN ] Error in file '/workspaces/model-registry/test/robot/MRkeywords.resource' on line 52: The '[Return]' setting is deprecated. Use the 'RETURN' statement instead.
[ WARN ] Error in file '/workspaces/model-registry/test/robot/MRkeywords.resource' on line 66: The '[Return]' setting is deprecated. Use the 'RETURN' statement instead.
[ WARN ] Error in file '/workspaces/model-registry/test/robot/MRkeywords.resource' on line 95: The '[Return]' setting is deprecated. Use the 'RETURN' statement instead.
[ WARN ] Error in file '/workspaces/model-registry/test/robot/MRkeywords.resource' on line 108: The '[Return]' setting is deprecated. Use the 'RETURN' statement instead.
[ WARN ] Error in file '/workspaces/model-registry/test/robot/MRkeywords.resource' on line 121: The '[Return]' setting is deprecated. Use the 'RETURN' statement instead.
[ WARN ] Error in file '/workspaces/model-registry/test/robot/MRkeywords.resource' on line 134: The '[Return]' setting is deprecated. Use the 'RETURN' statement instead.
Robot.MRandLogicalModel                                                       
==============================================================================
Verify basic logical mapping between MR and MLMD                      TEST SETUP
..{'createTimeSinceEpoch': '1705490518678', 'customProperties': {}, 'id': '21', 'lastUpdateTimeSinceEpoch': '1705490518678', 'name': 'jIsEXFel'}
.{'createTimeSinceEpoch': '1705490518894', 'customProperties': {}, 'id': '22', 'lastUpdateTimeSinceEpoch': '1705490518894', 'name': 'v1'}
.{'uri': 's3://12345', 'artifactType': 'model-artifact'}
{'artifactType': 'model-artifact', 'createTimeSinceEpoch': '1705490519157', 'customProperties': {}, 'id': '11', 'lastUpdateTimeSinceEpoch': '1705490519157', 'name': '06891c3e-f483-4f94-ad6c-58c5b99f1fb7', 'uri': 's3://12345'}
Verify basic logical mapping between MR and MLMD                      .id: 21 
type_id: 10
name: "jIsEXFel"
type: "odh.RegisteredModel"
create_time_since_epoch: 1705490518678
last_update_time_since_epoch: 1705490518678

After Update

> ==============================================================================
Robot                                                                         
==============================================================================
Robot.MRandLogicalModel                                                       
==============================================================================
Verify basic logical mapping between MR and MLMD                      TEST SETUP
..{'createTimeSinceEpoch': '1705490567998', 'customProperties': {}, 'id': '29', 'lastUpdateTimeSinceEpoch': '1705490567998', 'name': 'LQgmtCvr'}
.{'createTimeSinceEpoch': '1705490568182', 'customProperties': {}, 'id': '30', 'lastUpdateTimeSinceEpoch': '1705490568182', 'name': 'v1'}
.{'uri': 's3://12345', 'artifactType': 'model-artifact'}
{'artifactType': 'model-artifact', 'createTimeSinceEpoch': '1705490568415', 'customProperties': {}, 'id': '15', 'lastUpdateTimeSinceEpoch': '1705490568415', 'name': '35ac2d49-6173-4872-a47f-c90639bad673', 'uri': 's3://12345'}
Verify basic logical mapping between MR and MLMD                      .id: 29 
type_id: 10
name: "LQgmtCvr"
type: "odh.RegisteredModel"
create_time_since_epoch: 1705490567998
last_update_time_since_epoch: 1705490567998

....id: 30
type_id: 11
name: "29:v1"
properties {
  key: "author"
  value {
    string_value: ""
  }
}

> 