### PR TITLE
[RHOAIENG-2111] Added Dockerfile without generation phase

### DIFF
--- a/Dockerfile.odh
+++ b/Dockerfile.odh
@@ -1,0 +1,34 @@
+# Build the model-registry binary
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY ["go.mod", "go.sum", "./"]
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+USER root
+
+# Copy the go source
+COPY ["Makefile", "main.go", ".openapi-generator-ignore", "openapitools.json", "./"]
+
+# Copy rest of the source
+COPY bin/ bin/
+COPY cmd/ cmd/
+COPY api/ api/
+COPY internal/ internal/
+COPY pkg/ pkg/
+
+# Build
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 make clean/odh build/odh
+
+# Use distroless as minimal base image to package the model-registry binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
+WORKDIR /
+# copy the registry binary
+COPY --from=builder /workspace/model-registry .
+USER 65532:65532
+
+ENTRYPOINT ["/model-registry"]

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,10 @@ vet:
 clean:
 	rm -Rf ./model-registry internal/ml_metadata/proto/*.go internal/converter/generated/*.go pkg/openapi
 
+.PHONY: clean/odh
+clean/odh:
+	rm -Rf ./model-registry
+
 bin/go-enum:
 	GOBIN=$(PROJECT_BIN) go install github.com/searKing/golang/tools/go-enum@v1.2.97
 
@@ -147,12 +151,16 @@ vendor:
 build: gen vet lint
 	go build
 
+.PHONY: build/odh
+build/odh: vet lint
+	go build
+
 .PHONY: gen
 gen: deps gen/grpc gen/openapi gen/converter
 	go generate ./...
 
 .PHONY: lint
-lint: gen
+lint:
 	golangci-lint run main.go
 	golangci-lint run cmd/... internal/... ./pkg/...
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://issues.redhat.com/browse/RHOAIENG-2111

## Description
Provide additional `Dockerfile.odh` file that builds Model Registry without downloading external tools, hence without regenerating proto and openapi files.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested running:
```bash
docker build -t model-registry:RHOAIENG-2111 -f Dockerfile.odh .
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
