### PR TITLE
Remove lint from the build/odh cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ build: gen vet lint
 	go build
 
 .PHONY: build/odh
-build/odh: vet lint
+build/odh: vet
 	go build
 
 .PHONY: gen


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Remove the `linter` from the ODH build command, the assumption is that the build for odh/prod should rely on the existing source code, therefore there is no need to do the linting.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Running
```
make clean/odh build/odh
```
And then running the application. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
