### PR TITLE
add Shell script openshift-ci make some REST call to MR

### DIFF
--- a/test/scripts/rest.sh
+++ b/test/scripts/rest.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+make_post_extract_id() {
+    local url="$1"
+    local data="$2"
+    local id=$(curl -s -X POST "$url" \
+        -H 'accept: application/json' \
+        -H 'Content-Type: application/json' \
+        -d "$data" | jq -r '.id')
+
+    if [ -z "$id" ]; then
+        echo "Error: Failed to extract ID from response"
+        exit 1
+    fi
+
+    echo "$id"
+}
+
+# TODO: finalize using openshift-ci values.
+OCP_CLUSTER_NAME="rosa.mmortari-rosa-h.w0x4.p3.openshiftapps.com"
+MR_NAMESPACE="shared-modelregistry-ns"
+MR_HOSTNAME="http://modelregistry-sample-http-$MR_NAMESPACE.apps.$OCP_CLUSTER_NAME"
+
+timestamp=$(date +"%Y%m%d%H%M%S")
+rm_name="demo-$timestamp"
+
+rm_id=$(make_post_extract_id "$MR_HOSTNAME/api/model_registry/v1alpha1/registered_models" '{
+  "description": "lorem ipsum registered model",
+  "name": "'"$rm_name"'"
+}')
+
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+echo "Registered Model ID: $rm_id"
+
+mv_id=$(make_post_extract_id "$MR_HOSTNAME/api/model_registry/v1alpha1/model_versions" '{
+  "description": "lorem ipsum model version",
+  "name": "v1",
+  "author": "John Doe",
+  "registeredModelID": "'"$rm_id"'"
+}')
+
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+echo "Model Version ID: $mv_id"
+
+RAW_ML_MODEL_URI='https://huggingface.co/tarilabs/mnist/resolve/v1.nb20231206162408/mnist.onnx'
+ma_id=$(make_post_extract_id "$MR_HOSTNAME/api/model_registry/v1alpha1/model_versions/$mv_id/artifacts" '{
+  "description": "lorem ipsum model artifact",
+  "uri": "'"$RAW_ML_MODEL_URI"'",
+  "name": "mnist",
+  "modelFormatName": "onnx",
+  "modelFormatVersion": "1",
+  "storageKey": "aws-connection-unused",
+  "storagePath": "unused just demo",
+  "artifactType": "model-artifact"
+}')
+
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+echo "Model Artifact ID: $ma_id"
+
+ISVC_TARGET_NS=odh-project-b
+MODEL_SERVER_NAME=modelserverb
+
+oc apply -n $ISVC_TARGET_NS -f - <<EOF
+apiVersion: "serving.kserve.io/v1beta1"
+kind: "InferenceService"
+metadata:
+  name: "$rm_name"
+  annotations:
+    "openshift.io/display-name": "$rm_name"
+    "serving.kserve.io/deploymentMode": "ModelMesh"
+  labels:
+    "mr-registered-model-id": "$rm_id"
+    "mr-model-version-id": "$mv_id"
+    "mr-namespace": "$MR_NAMESPACE"
+    "opendatahub.io/dashboard": "true"
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: "onnx"
+        version: "1"
+      runtime: "$MODEL_SERVER_NAME"
+      storageUri: "$RAW_ML_MODEL_URI"
+EOF
+
+# TODO this will continue once we have MC PR merged from: https://github.com/opendatahub-io/odh-model-controller/pull/135
+iss_mr=$(curl -s -X 'GET' "$MR_HOSTNAME/api/model_registry/v1alpha1/inference_services" \
+        -H 'accept: application/json')
+
+echo "InferenceService entities on MR:"
+echo "$iss_mr"

--- a/test/scripts/rest.sh
+++ b/test/scripts/rest.sh
@@ -17,7 +17,7 @@ make_post_extract_id() {
 }
 
 # TODO: finalize using openshift-ci values.
-OCP_CLUSTER_NAME="rosa.mmortari-rosa-h.w0x4.p3.openshiftapps.com"
+OCP_CLUSTER_NAME="PROVIDE OCP CLUSTER NAME FOR OPENSHIFT-CI"
 MR_NAMESPACE="shared-modelregistry-ns"
 MR_HOSTNAME="http://modelregistry-sample-http-$MR_NAMESPACE.apps.$OCP_CLUSTER_NAME"
 


### PR DESCRIPTION
In the scope of testing of Model Registry in openshift-ci:
- make a Shell script which invokes some REST calls to MR,
- so to make sure the REST endpoint is responsive,
- then create a K8s ISVC on the cluster,
- and display the MR InferenceService entities.

Later, in a subsequent issue/PR, once:
- opendatahub-io/odh-model-controller#135

is merged, the last bulletpoint can be automated and placed under test in the final part of this script so to make sure the K8s ISVC on the cluster reflected as a precise MR InferenceService entity.

## Description
Resolves #294 

## How Has This Been Tested?
Tested with:
```sh
OCP_CLUSTER_NAME="rosa.mmortari-rosa-h.w0x4.p3.openshiftapps.com"
```

Result:
```
Registered Model ID: 27
Model Version ID: 28
Model Artifact ID: 14
inferenceservice.serving.kserve.io/demo-20240208144831 created
InferenceService entities on MR:
{"items":[],"nextPageToken":"","pageSize":0,"size":0}
```

![Screenshot 2024-02-08 at 14 48 57](https://github.com/opendatahub-io/model-registry/assets/1699252/4843ee18-2f53-4a0c-8070-10cb0923de8e)

![Screenshot 2024-02-08 at 14 49 04](https://github.com/opendatahub-io/model-registry/assets/1699252/3e5eeaef-4ff8-4bf1-922f-adb250d3f5ed)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
