### PR TITLE
add Homepage, Issues on pyproject.toml for PyPI

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -6,6 +6,10 @@ authors = ["Isabella Basso do Amaral <idoamara@redhat.com>"]
 license = "Apache-2.0"
 readme = "README.md"
 
+[project.urls]
+Homepage = "https://github.com/opendatahub-io/model-registry"
+Issues = "https://github.com/opendatahub-io/model-registry/issues"
+
 [tool.poetry.dependencies]
 python = ">= 3.9, < 3.11"
 attrs = "^21.0"

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -5,10 +5,10 @@ description = "Client for Red Hat OpenDataHub Model Registry"
 authors = ["Isabella Basso do Amaral <idoamara@redhat.com>"]
 license = "Apache-2.0"
 readme = "README.md"
+homepage = "https://github.com/opendatahub-io/model-registry"
 
-[project.urls]
-Homepage = "https://github.com/opendatahub-io/model-registry"
-Issues = "https://github.com/opendatahub-io/model-registry/issues"
+[tool.poetry.urls]
+"Issues" = "https://github.com/opendatahub-io/model-registry/issues"
 
 [tool.poetry.dependencies]
 python = ">= 3.9, < 3.11"


### PR DESCRIPTION
Resolves #298 

## Description
As of today we're missing some hyperlinks from PyPI to "checkout source" of the MR Python client, if compared to other projects on PyPI.
![Screenshot 2024-02-09 at 11 27 42](https://github.com/opendatahub-io/model-registry/assets/1699252/3cb89214-6418-4975-9493-46bbf0582b69)
When we will uplift to KF, we can always update the references.


## How Has This Been Tested?
n/a

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [n/a] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [n/a] The developer has manually tested the changes and verified that the changes work
