### PR TITLE
Creating OWNERS file needed for openshift-ci

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,25 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/opendatahub-io/codeflare-operator root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- dhirajsb
+- isinyaaa
+- lampajr
+- nehachopra27
+- rareddy
+- rkubis
+- tarilabs
+- tonyxrmdavidson
+options: {}
+reviewers:
+- dhirajsb
+- isinyaaa
+- lampajr
+- nehachopra27
+- rareddy
+- rkubis
+- tarilabs
+- tonyxrmdavidson


### PR DESCRIPTION
Creating OWNERS file needed for openshift-ci. Including Neha Chopra (nehachopra27) in the OWNERS file as Neha will be added to the team as a contributor to model-registry.