### PR TITLE
py: default metadata capture environment vars

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -37,6 +37,11 @@ version = registry.get_model_version("my-model", "v2.0")
 experiment = registry.get_model_artifact("my-model", "v2.0")
 ```
 
+### Default values for metadata
+
+If not supplied, `metadata` values defaults to a predefined set of conventional values.
+Reference the technical documentation in the pydoc of the client.
+
 ### Importing from Hugging Face Hub
 
 To import models from Hugging Face Hub, start by installing the `huggingface-hub` package, either directly or as an

--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -100,7 +100,7 @@ class ModelRegistry:
             storage_path: Storage path.
             service_account_name: Service account name.
             metadata: Additional version metadata. Defaults to values returned by `default_metadata()`.
-        
+
         Returns:
             Registered model.
         """
@@ -123,9 +123,9 @@ class ModelRegistry:
         )
 
         return rm
-    
+
     def default_metadata(self) -> dict[str, ScalarType]:
-        """Default metadata valorisations
+        """Default metadata valorisations.
 
         When not explicitly supplied by the end users, these valorisations will be used
         by default.
@@ -134,7 +134,7 @@ class ModelRegistry:
             default metadata valorisations.
         """
         return {
-            key: os.environ[key] for key in ['AWS_S3_ENDPOINT', 'AWS_S3_BUCKET', 'AWS_DEFAULT_REGION'] if key in os.environ
+            key: os.environ[key] for key in ["AWS_S3_ENDPOINT", "AWS_S3_BUCKET", "AWS_DEFAULT_REGION"] if key in os.environ
         }
 
     def register_hf_model(

--- a/clients/python/src/model_registry/_client.py
+++ b/clients/python/src/model_registry/_client.py
@@ -1,6 +1,7 @@
 """Standard client for the model registry."""
 from __future__ import annotations
 
+import os
 from typing import get_args
 from warnings import warn
 
@@ -98,8 +99,8 @@ class ModelRegistry:
             storage_key: Storage key.
             storage_path: Storage path.
             service_account_name: Service account name.
-            metadata: Additional version metadata.
-
+            metadata: Additional version metadata. Defaults to values returned by `default_metadata()`.
+        
         Returns:
             Registered model.
         """
@@ -109,7 +110,7 @@ class ModelRegistry:
             version,
             author or self._author,
             description=description,
-            metadata=metadata or {},
+            metadata=metadata or self.default_metadata(),
         )
         self._register_model_artifact(
             mv,
@@ -122,6 +123,19 @@ class ModelRegistry:
         )
 
         return rm
+    
+    def default_metadata(self) -> dict[str, ScalarType]:
+        """Default metadata valorisations
+
+        When not explicitly supplied by the end users, these valorisations will be used
+        by default.
+
+        Returns:
+            default metadata valorisations.
+        """
+        return {
+            key: os.environ[key] for key in ['AWS_S3_ENDPOINT', 'AWS_S3_BUCKET', 'AWS_DEFAULT_REGION'] if key in os.environ
+        }
 
     def register_hf_model(
         self,
@@ -188,6 +202,7 @@ class ModelRegistry:
             model_author = author
         source_uri = hf_hub_url(repo, path, revision=git_ref)
         metadata = {
+            **self.default_metadata(),
             "repo": repo,
             "source_uri": source_uri,
             "model_origin": "huggingface_hub",

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -1,5 +1,6 @@
-import pytest
 import os
+
+import pytest
 from model_registry import ModelRegistry
 from model_registry.core import ModelRegistryAPIClient
 from model_registry.exceptions import StoreException
@@ -90,7 +91,7 @@ def test_default_md(mr_client: ModelRegistry):
     assert (mv := mr_client.get_model_version(name, version))
     assert mv.metadata == env_values
 
-    for k in env_values.keys():
+    for k in env_values:
         os.environ.pop(k)
 
 
@@ -127,7 +128,7 @@ def test_hf_import_default_env(mr_client: ModelRegistry):
     env_values = {"AWS_S3_ENDPOINT": "value1", "AWS_S3_BUCKET": "value2", "AWS_DEFAULT_REGION": "value3"}
     for k, v in env_values.items():
         os.environ[k] = v
-    
+
     assert mr_client.register_hf_model(
         name,
         "onnx/decoder_model.onnx",
@@ -143,5 +144,5 @@ def test_hf_import_default_env(mr_client: ModelRegistry):
     assert mv.metadata["repo"] == name
     assert mr_client.get_model_artifact(name, version)
 
-    for k in env_values.keys():
+    for k in env_values:
         os.environ.pop(k)

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 from model_registry import ModelRegistry
 from model_registry.core import ModelRegistryAPIClient
 from model_registry.exceptions import StoreException
@@ -46,6 +47,7 @@ def test_register_existing_version(mr_client: ModelRegistry):
 def test_get(mr_client: ModelRegistry):
     name = "test_model"
     version = "1.0.0"
+    metadata = {"a": 1, "b": "2"}
 
     rm = mr_client.register_model(
         name,
@@ -53,6 +55,7 @@ def test_get(mr_client: ModelRegistry):
         model_format_name="test_format",
         model_format_version="test_version",
         version=version,
+        metadata=metadata
     )
 
     assert (_rm := mr_client.get_registered_model(name))
@@ -64,22 +67,81 @@ def test_get(mr_client: ModelRegistry):
 
     assert (_mv := mr_client.get_model_version(name, version))
     assert mv.id == _mv.id
+    assert mv.metadata == metadata
     assert (_ma := mr_client.get_model_artifact(name, version))
     assert ma.id == _ma.id
+
+
+def test_default_md(mr_client: ModelRegistry):
+    name = "test_model"
+    version = "1.0.0"
+    env_values = {"AWS_S3_ENDPOINT": "value1", "AWS_S3_BUCKET": "value2", "AWS_DEFAULT_REGION": "value3"}
+    for k, v in env_values.items():
+        os.environ[k] = v
+
+    assert mr_client.register_model(
+        name,
+        "s3",
+        model_format_name="test_format",
+        model_format_version="test_version",
+        version=version,
+        # ensure leave empty metadata
+    )
+    assert (mv := mr_client.get_model_version(name, version))
+    assert mv.metadata == env_values
+
+    for k in env_values.keys():
+        os.environ.pop(k)
 
 
 def test_hf_import(mr_client: ModelRegistry):
     pytest.importorskip("huggingface_hub")
     name = "openai-community/gpt2"
     version = "1.2.3"
+    author = "test author"
 
     assert mr_client.register_hf_model(
         name,
         "onnx/decoder_model.onnx",
-        author="test author",
+        author=author,
         version=version,
         model_format_name="test format",
         model_format_version="test version",
     )
-    assert mr_client.get_model_version(name, version)
+    assert (mv := mr_client.get_model_version(name, version))
+    assert mv.author == author
+    assert mv.metadata["model_author"] == author
+    assert mv.metadata["model_origin"] == "huggingface_hub"
+    assert mv.metadata["source_uri"] == "https://huggingface.co/openai-community/gpt2/resolve/main/onnx/decoder_model.onnx"
+    assert mv.metadata["repo"] == name
     assert mr_client.get_model_artifact(name, version)
+
+
+def test_hf_import_default_env(mr_client: ModelRegistry):
+    """Test setting environment variables, hence triggering defaults, does _not_ interfere with HF metadata
+    """
+    pytest.importorskip("huggingface_hub")
+    name = "openai-community/gpt2"
+    version = "1.2.3"
+    author = "test author"
+    env_values = {"AWS_S3_ENDPOINT": "value1", "AWS_S3_BUCKET": "value2", "AWS_DEFAULT_REGION": "value3"}
+    for k, v in env_values.items():
+        os.environ[k] = v
+    
+    assert mr_client.register_hf_model(
+        name,
+        "onnx/decoder_model.onnx",
+        author=author,
+        version=version,
+        model_format_name="test format",
+        model_format_version="test version",
+    )
+    assert (mv := mr_client.get_model_version(name, version))
+    assert mv.metadata["model_author"] == author
+    assert mv.metadata["model_origin"] == "huggingface_hub"
+    assert mv.metadata["source_uri"] == "https://huggingface.co/openai-community/gpt2/resolve/main/onnx/decoder_model.onnx"
+    assert mv.metadata["repo"] == name
+    assert mr_client.get_model_artifact(name, version)
+
+    for k in env_values.keys():
+        os.environ.pop(k)


### PR DESCRIPTION
Resolves #306 

## Description
Following examples provided in https://github.com/opendatahub-io/model-registry/pull/301
provide mechanism in Python client for "default values"
without capturing credentials.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [n/a] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
