### PR TITLE
Add parentResourceID param for FindInferenceService

### DIFF
--- a/api/openapi/model-registry.yaml
+++ b/api/openapi/model-registry.yaml
@@ -482,6 +482,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/name"
       - $ref: "#/components/parameters/externalID"
+      - $ref: "#/components/parameters/parentResourceID"
   "/api/model_registry/v1alpha1/inference_services/{inferenceserviceId}":
     summary: Path used to manage a single InferenceService.
     description: >-

--- a/internal/server/openapi/api.go
+++ b/internal/server/openapi/api.go
@@ -71,7 +71,7 @@ type ModelRegistryServiceAPIServicer interface {
 	CreateRegisteredModel(context.Context, model.RegisteredModelCreate) (ImplResponse, error)
 	CreateRegisteredModelVersion(context.Context, string, model.ModelVersion) (ImplResponse, error)
 	CreateServingEnvironment(context.Context, model.ServingEnvironmentCreate) (ImplResponse, error)
-	FindInferenceService(context.Context, string, string) (ImplResponse, error)
+	FindInferenceService(context.Context, string, string, string) (ImplResponse, error)
 	FindModelArtifact(context.Context, string, string, string) (ImplResponse, error)
 	FindModelVersion(context.Context, string, string, string) (ImplResponse, error)
 	FindRegisteredModel(context.Context, string, string) (ImplResponse, error)

--- a/internal/server/openapi/api_model_registry_service.go
+++ b/internal/server/openapi/api_model_registry_service.go
@@ -482,7 +482,8 @@ func (c *ModelRegistryServiceAPIController) FindInferenceService(w http.Response
 	query := r.URL.Query()
 	nameParam := query.Get("name")
 	externalIDParam := query.Get("externalID")
-	result, err := c.service.FindInferenceService(r.Context(), nameParam, externalIDParam)
+	parentResourceIDParam := query.Get("parentResourceID")
+	result, err := c.service.FindInferenceService(r.Context(), nameParam, externalIDParam, parentResourceIDParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/internal/server/openapi/api_model_registry_service_service.go
+++ b/internal/server/openapi/api_model_registry_service_service.go
@@ -165,8 +165,8 @@ func (s *ModelRegistryServiceAPIService) CreateServingEnvironment(ctx context.Co
 }
 
 // FindInferenceService - Get an InferenceServices that matches search parameters.
-func (s *ModelRegistryServiceAPIService) FindInferenceService(ctx context.Context, name string, externalID string) (ImplResponse, error) {
-	result, err := s.coreApi.GetInferenceServiceByParams(&name, nil, &externalID)
+func (s *ModelRegistryServiceAPIService) FindInferenceService(ctx context.Context, name string, externalID string, parentResourceID string) (ImplResponse, error) {
+	result, err := s.coreApi.GetInferenceServiceByParams(&name, &parentResourceID, &externalID)
 	if err != nil {
 		return Response(500, model.Error{Message: err.Error()}), nil
 	}

--- a/pkg/openapi/api_model_registry_service.go
+++ b/pkg/openapi/api_model_registry_service.go
@@ -1379,10 +1379,11 @@ func (a *ModelRegistryServiceAPIService) CreateServingEnvironmentExecute(r ApiCr
 }
 
 type ApiFindInferenceServiceRequest struct {
-	ctx        context.Context
-	ApiService *ModelRegistryServiceAPIService
-	name       *string
-	externalID *string
+	ctx              context.Context
+	ApiService       *ModelRegistryServiceAPIService
+	name             *string
+	externalID       *string
+	parentResourceID *string
 }
 
 // Name of entity to search.
@@ -1394,6 +1395,12 @@ func (r ApiFindInferenceServiceRequest) Name(name string) ApiFindInferenceServic
 // External ID of entity to search.
 func (r ApiFindInferenceServiceRequest) ExternalID(externalID string) ApiFindInferenceServiceRequest {
 	r.externalID = &externalID
+	return r
+}
+
+// ID of the parent resource to use for search.
+func (r ApiFindInferenceServiceRequest) ParentResourceID(parentResourceID string) ApiFindInferenceServiceRequest {
+	r.parentResourceID = &parentResourceID
 	return r
 }
 
@@ -1443,6 +1450,9 @@ func (a *ModelRegistryServiceAPIService) FindInferenceServiceExecute(r ApiFindIn
 	}
 	if r.externalID != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "externalID", r.externalID, "")
+	}
+	if r.parentResourceID != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "parentResourceID", r.parentResourceID, "")
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/opendatahub-io/model-registry/issues/310 

## Description
<!--- Describe your changes in detail -->
Add new REST parameter (i.e., `parentResourceID`) for `FindInferenceService` operation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Start MLMD
2. Start proxy using `make proxy`
3. Register model, version and serving env
4. Create an inference service
5. Then get it by `name` and `servingEnvId`:
```
curl --silent -X 'GET' \ 
  "$MR_HOSTNAME/api/model_registry/v1alpha1/inference_service?name=<IS_NAME>&parentResourceID=<ENV_ID>" \
  -H 'accept: application/json' | jq
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
